### PR TITLE
Add hover styling for workflow lab handles

### DIFF
--- a/frontend/frontend/src/components/css/workflow_lab_css/AiWorkflowLab.css
+++ b/frontend/frontend/src/components/css/workflow_lab_css/AiWorkflowLab.css
@@ -63,3 +63,13 @@
 .handle-source {
   background-color: #28a745;
 }
+
+.handle-target:hover {
+  background-color: #1c86ee;
+  box-shadow: 0 0 6px rgba(30, 144, 255, 0.5);
+}
+
+.handle-source:hover {
+  background-color: #23913d;
+  box-shadow: 0 0 6px rgba(40, 167, 69, 0.5);
+}

--- a/frontend/frontend/src/components/workflow_lab_components/AiWorkLabNodeSizer.jsx
+++ b/frontend/frontend/src/components/workflow_lab_components/AiWorkLabNodeSizer.jsx
@@ -20,7 +20,7 @@ const AiWorkLabNodeSizer = ({ data, selected }) => {
         }}
       />
 
-      {/* Target (input) */}
+      {/* Target (input) handle styled via .handle-target */}
       <Handle
         type="target"
         position={Position.Left}
@@ -65,7 +65,7 @@ const AiWorkLabNodeSizer = ({ data, selected }) => {
         </div>
       </div>
 
-      {/* Source (output) */}
+      {/* Source (output) handle styled via .handle-source */}
       <Handle
         type="source"
         position={Position.Right}


### PR DESCRIPTION
## Summary
- add subtle hover glow for `handle-target` and `handle-source`
- clarify comments around handle styles

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68521b96c6e0832e95d45d516c12c3e8