### PR TITLE
Change whiteboard default background to light blue

### DIFF
--- a/frontend/frontend/src/components/white_board_components/WhiteBoard.jsx
+++ b/frontend/frontend/src/components/white_board_components/WhiteBoard.jsx
@@ -6,12 +6,18 @@ import WhiteboardToolbar from "./WhiteBoardToolbar";
 
 const Whiteboard = () => {
   const excalidrawRef = useRef(null);
+  // Set initial background color to light blue
+  const initialData = {
+    appState: {
+      viewBackgroundColor: "#add8e6",
+    },
+  };
 
   return (
     <div style={{ height: "100%", width: "100%", display: "flex", flexDirection: "column" }}>
       <WhiteboardToolbar excalidrawRef={excalidrawRef} />
       <div style={{ flex: 1 }}>
-        <Excalidraw ref={excalidrawRef} />
+        <Excalidraw ref={excalidrawRef} initialData={initialData} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- update WhiteBoard component so Excalidraw starts with a light blue canvas

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68522c570880832e8755bcce4c8575de