### PR TITLE
Add PDF export for AI report

### DIFF
--- a/frontend/frontend/package.json
+++ b/frontend/frontend/package.json
@@ -25,6 +25,7 @@
     "react-icons": "^5.3.0",
     "react-scripts": "5.0.1",
     "reactflow": "^11.11.4",
+    "html2canvas": "^1.4.1",
     "styled-components": "^6.1.16",
     "view-json-react": "^1.1.2",
     "web-vitals": "^2.1.4"

--- a/frontend/frontend/src/components/css/AIReporter.css
+++ b/frontend/frontend/src/components/css/AIReporter.css
@@ -1,0 +1,15 @@
+.export-report-button {
+    background-color: #b0b0b0; /* Nintendo grey */
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    color: #333;
+    border: 1px solid #888;
+    padding: 10px 20px;
+    cursor: pointer;
+    border-radius: 4px;
+    transition: background-color 0.3s ease, transform 0.2s ease;
+}
+
+.export-report-button:hover {
+    background-color: #999;
+    transform: scale(1.05);
+}

--- a/frontend/frontend/src/components/workflow_lab_components/AIReporter.jsx
+++ b/frontend/frontend/src/components/workflow_lab_components/AIReporter.jsx
@@ -1,6 +1,9 @@
 // src/components/workflow_lab_components/AIReporter.jsx
-import React from "react";
+import React, { useRef } from "react";
 import AICharts from "../ai_ml_components/AICharts";
+import { jsPDF } from "jspdf";
+import html2canvas from "html2canvas";
+import "../css/AIReporter.css";
 
 const Section = ({ title, content }) => (
   <div style={{ marginBottom: "24px" }}>
@@ -30,17 +33,31 @@ const asText = (val) =>
 
 // AIReporter.jsx
 const AIReporter = ({ summary, insights, execution, chartType, chartData }) => {
+  const reportRef = useRef(null);
+
+  const handleExportPDF = async () => {
+    if (!reportRef.current) return;
+    const canvas = await html2canvas(reportRef.current);
+    const imgData = canvas.toDataURL("image/png");
+    const pdf = new jsPDF({
+      orientation: "portrait",
+      unit: "px",
+      format: [canvas.width, canvas.height],
+    });
+    pdf.addImage(imgData, "PNG", 0, 0, canvas.width, canvas.height);
+    pdf.save("ai_report.pdf");
+  };
+
   console.log(
-    `AIReporter PROPS: chartType: '${chartType}', chartData (FULL):`, chartData, // Log the full array
+    `AIReporter PROPS: chartType: '${chartType}', chartData (FULL):`, chartData,
     `| typeof: ${typeof chartData}`,
     `| isArray: ${Array.isArray(chartData)}`,
     `| length: ${Array.isArray(chartData) ? chartData.length : 'N/A'}`
-    // The 'first element' part can be removed if you're logging the full array,
-    // as you can inspect it in the browser console.
   );
- // }
+
   return (
     <div
+      ref={reportRef}
       style={{
         background: "#f9f9f9",
         border: "1px solid #ccc",
@@ -68,7 +85,11 @@ const AIReporter = ({ summary, insights, execution, chartType, chartData }) => {
             }
           />
         )}
-
+      <div style={{ textAlign: "center", marginTop: "24px" }}>
+        <button className="export-report-button" onClick={handleExportPDF}>
+          Export Report as PDF
+        </button>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add html2canvas to frontend dependencies
- implement export button in `AIReporter` to save report as PDF
- style export button with new CSS

## Testing
- `npm test --silent` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854def2d714832e9d8e746ca3f8c68a