### PR TITLE
Add persistent component state tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ cleanedData: Holds the cleaned dataset for export and visualization.
 
 xAxis & yAxis: Stores selected fields for charting.
 
+WindowContext now preserves component-level state. Use `saveComponentState(id, state)`
+and `getComponentState(id)` to keep windows like the Workflow Lab and White Board
+intact when minimized.
+
 AI Integration
 
 Uses OpenAI GPT-4 for AI-generated dataset insights and chart suggestions.

--- a/frontend/frontend/src/components/white_board_components/WhiteBoard.jsx
+++ b/frontend/frontend/src/components/white_board_components/WhiteBoard.jsx
@@ -1,23 +1,46 @@
 // Whiteboard.jsx
-import React, { useRef } from "react";
+import React, { useRef, useEffect } from "react";
 import { Excalidraw } from "@excalidraw/excalidraw";
 import "@excalidraw/excalidraw/index.css";
 import WhiteboardToolbar from "./WhiteBoardToolbar";
+import { useWindowContext } from "../../context/WindowContext";
 
 const Whiteboard = () => {
   const excalidrawRef = useRef(null);
+  const { saveComponentState, getComponentState } = useWindowContext();
+  const savedScene = getComponentState('whiteBoard');
   // Set initial background color to light blue
-  const initialData = {
+  const initialData = savedScene || {
     appState: {
       viewBackgroundColor: "#add8e6",
     },
   };
 
+  useEffect(() => {
+    return () => {
+      if (excalidrawRef.current) {
+        const elements = excalidrawRef.current.getSceneElements();
+        const appState = excalidrawRef.current.getAppState();
+        saveComponentState('whiteBoard', { elements, appState });
+      }
+    };
+  }, [saveComponentState]);
+
   return (
     <div style={{ height: "100%", width: "100%", display: "flex", flexDirection: "column" }}>
       <WhiteboardToolbar excalidrawRef={excalidrawRef} />
       <div style={{ flex: 1 }}>
-        <Excalidraw ref={excalidrawRef} initialData={initialData} />
+        <Excalidraw
+          ref={excalidrawRef}
+          initialData={initialData}
+          onChange={() => {
+            if (excalidrawRef.current) {
+              const elements = excalidrawRef.current.getSceneElements();
+              const appState = excalidrawRef.current.getAppState();
+              saveComponentState('whiteBoard', { elements, appState });
+            }
+          }}
+        />
       </div>
     </div>
   );

--- a/frontend/frontend/src/components/workflow_lab_components/AiWorkflowLab.jsx
+++ b/frontend/frontend/src/components/workflow_lab_components/AiWorkflowLab.jsx
@@ -1,6 +1,6 @@
 // 📂 AiWorkflowLab.jsx — cleaned and fixed DropZone behavior with working hover
 
-import { useState, useCallback, useContext, useRef } from "react";
+import { useState, useCallback, useContext, useRef, useEffect } from "react";
 import {
   ReactFlow,
   Controls,
@@ -19,6 +19,7 @@ import ContextMenu from "../../context/ContextMenu";
 import { DataContext } from "../../context/DataContext";
 import AIPipeline from './AIPipeline';
 import DropZoneNode from './DropZoneNode';
+import { useWindowContext } from "../../context/WindowContext";
 
 const initialNodes = [
   {
@@ -36,8 +37,10 @@ const initialEdges = [];
 
 function AiWorkflowLab() {
   const { uploadedData, cleanedData, pipelineResults, setPipelineResults, setCleanedData } = useContext(DataContext);
-  const [nodes, setNodes] = useState(initialNodes);
-  const [edges, setEdges] = useState(initialEdges);
+  const { saveComponentState, getComponentState } = useWindowContext();
+  const savedState = getComponentState('aiWorkflowLab');
+  const [nodes, setNodes] = useState(savedState?.nodes || initialNodes);
+  const [edges, setEdges] = useState(savedState?.edges || initialEdges);
   const [hasExecuted, setHasExecuted] = useState(false);
 
   const workflowRef = useRef(null);
@@ -122,6 +125,16 @@ function AiWorkflowLab() {
     (changes) => setEdges((eds) => applyEdgeChanges(changes, eds)),
     []
   );
+
+  useEffect(() => {
+    saveComponentState('aiWorkflowLab', { nodes, edges });
+  }, [nodes, edges, saveComponentState]);
+
+  useEffect(() => {
+    return () => {
+      saveComponentState('aiWorkflowLab', { nodes, edges });
+    };
+  }, [nodes, edges, saveComponentState]);
 
   const handleAddNode = useCallback(
     (type) => {

--- a/frontend/frontend/src/context/WindowContext.jsx
+++ b/frontend/frontend/src/context/WindowContext.jsx
@@ -6,6 +6,7 @@ export const WindowProvider = ({ children }) => {
   const [openWindows, setOpenWindows] = useState([]);
   const [minimizedWindows, setMinimizedWindows] = useState({});
   const [windowStates, setWindowStates] = useState({});
+  const [componentStates, setComponentStates] = useState({});
   const [lockedWindows, setLockedWindows] = useState({});
 
 
@@ -19,6 +20,12 @@ export const WindowProvider = ({ children }) => {
 };
 
   const getWindowState = (id) => windowStates[id] || null;
+
+  const saveComponentState = (id, state) => {
+    setComponentStates(prev => ({ ...prev, [id]: state }));
+  };
+
+  const getComponentState = id => componentStates[id];
 
   const toggleLock = (id) => {
   setLockedWindows(prev => ({ ...prev, [id]: !prev[id] }));
@@ -70,10 +77,13 @@ export const WindowProvider = ({ children }) => {
       maximizeWindow,
       saveWindowState,
       getWindowState,
+      saveComponentState,
+      getComponentState,
       toggleLock,
       isLocked,
+      componentStates,
     }),
-    [openWindows, minimizedWindows, windowStates, lockedWindows]
+    [openWindows, minimizedWindows, windowStates, componentStates, lockedWindows]
   );
 
   return <WindowContext.Provider value={value}>{children}</WindowContext.Provider>;


### PR DESCRIPTION
## Summary
- extend `WindowContext` with per-component state helpers
- persist data for `AiWorkflowLab` nodes/edges
- save and restore whiteboard scenes
- document component state persistence

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688c42f3381c832e978c209607312d7b