### PR TITLE
feat: modernize whiteboard light/dark themes

### DIFF
--- a/frontend/frontend/src/components/css/white_board_css/WhiteBoardModern.css
+++ b/frontend/frontend/src/components/css/white_board_css/WhiteBoardModern.css
@@ -6,28 +6,28 @@
 
   /* light theme defaults */
   --toolbar-bg: rgba(255, 255, 255, 0.9);
-  --toolbar-border: #d8d6d0;
+  --toolbar-border: #e0e0e0;
   --toolbar-button-bg: #ffffff;
-  --toolbar-button-hover-bg: #f3f2ef;
+  --toolbar-button-hover-bg: #f5f5f5;
   --toolbar-button-text: #2d2d2d;
   --toolbar-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
-  --canvas-bg: #fefdfb;
-  --canvas-border: #e3e0da;
-  --canvas-dot-color: #e1e0db;
+  --canvas-bg: #fdfdfd;
+  --canvas-border: #e5e5e5;
+  --canvas-dot-color: #e0e0e0;
   --canvas-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
 }
 
 @media (prefers-color-scheme: dark) {
   .whiteboard-modern {
-    --toolbar-bg: rgba(44, 54, 70, 0.75);
+    --toolbar-bg: rgba(40, 48, 64, 0.75);
     --toolbar-border: rgba(255, 255, 255, 0.08);
-    --toolbar-button-bg: rgba(55, 65, 80, 0.9);
-    --toolbar-button-hover-bg: rgba(65, 75, 90, 0.9);
-    --toolbar-button-text: #e5e7eb;
+    --toolbar-button-bg: rgba(55, 65, 82, 0.9);
+    --toolbar-button-hover-bg: rgba(65, 75, 95, 0.9);
+    --toolbar-button-text: #f3f4f6;
     --toolbar-shadow: 0 2px 6px rgba(0, 0, 0, 0.6);
-    --canvas-bg: #1e2533;
+    --canvas-bg: #1c2230;
     --canvas-border: #2a3342;
-    --canvas-dot-color: #4b5567;
+    --canvas-dot-color: #3a4255;
     --canvas-shadow: 0 2px 10px rgba(0, 0, 0, 0.6);
   }
 }
@@ -58,6 +58,26 @@
 
 .whiteboard-modern .wb-toolbar button:hover {
   background-color: var(--toolbar-button-hover-bg);
+}
+
+/* Excalidraw built-in UI elements */
+.whiteboard-modern .excalidraw .layer-ui__wrapper > div {
+  background-color: var(--toolbar-bg) !important;
+  border: 1px solid var(--toolbar-border) !important;
+  border-radius: 8px;
+  box-shadow: var(--toolbar-shadow);
+  backdrop-filter: blur(6px);
+}
+
+.whiteboard-modern .excalidraw .layer-ui__wrapper button {
+  background-color: var(--toolbar-button-bg) !important;
+  color: var(--toolbar-button-text) !important;
+  border: 1px solid var(--toolbar-border);
+  border-radius: 4px;
+}
+
+.whiteboard-modern .excalidraw .layer-ui__wrapper button:hover {
+  background-color: var(--toolbar-button-hover-bg) !important;
 }
 
 .whiteboard-modern .wb-canvas {


### PR DESCRIPTION
## Summary
- restyle whiteboard CSS with light mode default and dark mode via prefers-color-scheme
- add themed variables for toolbar and canvas plus Excalidraw UI elements

## Testing
- `CI=true npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68b25d7f54e0832eba81f48d87b1d708