### PR TITLE
fix: display raw data viewer

### DIFF
--- a/frontend/frontend/src/App.jsx
+++ b/frontend/frontend/src/App.jsx
@@ -167,16 +167,34 @@ function App() {
   }, [setUploadedData, setFullData, setCleanedData]);
 
   const handleApiData = (data) => {
+    const rows = Array.isArray(data)
+      ? data
+      : Array.isArray(data?.data_preview)
+      ? data.data_preview
+      : typeof data?.data_preview === 'string'
+      ? JSON.parse(data.data_preview)
+      : [];
+
     setUploadedData({
-      data_preview: Array.isArray(data) ? data : [data], // ✅ Ensures correct format
+      data_preview: rows, // ✅ Ensures correct format
     });
+    setFullData(rows);      // ✅ Provide full dataset
+    setCleanedData(rows);   // ✅ Keep sidebar fields in sync
     setShowDataPreview(true);  // ✅ Triggers preview window
   };
 
   const handleDatabaseData = (data) => {
+    const rows = Array.isArray(data?.data_preview)
+      ? data.data_preview
+      : typeof data?.data_preview === 'string'
+      ? JSON.parse(data.data_preview)
+      : [];
+
     setUploadedData({
-      data_preview: Array.isArray(data?.data_preview) ? data.data_preview : []
+      data_preview: rows,
     });
+    setFullData(rows);      // ✅ Provide full dataset
+    setCleanedData(rows);   // ✅ Keep sidebar fields in sync
     setShowDataPreview(true);
   };
   
@@ -192,7 +210,7 @@ function App() {
   }, []);
 
   const handleCloseRawViewer = useCallback(() => {
-    setShowRawViewer(true);
+    setShowRawViewer(false);
   }, []);
 
   const handleCloseCanvas = useCallback(() => {

--- a/frontend/frontend/src/components/CanvasContainer.jsx
+++ b/frontend/frontend/src/components/CanvasContainer.jsx
@@ -319,19 +319,8 @@ const { fullData } = useContext(DataContext);
         })()
       : null;
 
-  // ⬇️ Prereqs inside CanvasContainer component body (near other hooks/state):
-// const { fullData } = useContext(DataContext);   // make sure DataContext is imported
-// props expected: showRawViewer (bool), handleCloseRawViewer (fn)
-console.log('[Raw Guard] showRawViewer:', showRawViewer);
-console.log('[Raw Guard] fullData length:', Array.isArray(fullData) ? fullData.length : 'not array');
-console.log('[Raw Guard] minimized:', minimizedWindows['rawViewer']);
-
 const rawDataElement =
-  showRawViewer &&
-  Array.isArray(fullData) &&
-  fullData.length > 0 &&
-  !minimizedWindows['rawViewer']
-  
+  showRawViewer && !minimizedWindows['rawViewer']
     ? (() => {
         const saved = getWindowState('rawViewer');
         const layout = registerLayout(
@@ -389,7 +378,10 @@ const rawDataElement =
             >
               {/* Prefer a paginated viewer to avoid freezing on large datasets */}
               {/* If you created RawDataViewer, use it: */}
-              <RawDataViewer rows={fullData} pageSize={500} /> 
+              <RawDataViewer
+                rows={Array.isArray(fullData) ? fullData : []}
+                pageSize={500}
+              />
 
             </div>
           </div>

--- a/frontend/frontend/src/components/SideBar.jsx
+++ b/frontend/frontend/src/components/SideBar.jsx
@@ -35,13 +35,6 @@ const SideBar = ({ onButtonClick, onDataCleaned,
   const [showDataViewerOptions, setShowDataViewerOptions] = useState(false)
                
                   
-  console.log('cleanedData in SideBar:', cleanedData);
-  console.log("Type of cleanedData:", typeof cleanedData);
-  if (!cleanedData) {
-    console.warn("cleanedData is NULL or UNDEFINED in SideBar.");
-    console.log('AI Models available:', storyModel)
-    console.log('Here are the data viewer options: ', showDataViewerOptions)
-}
   // Toggles DataCleaningForm visibility
   const handleDataCleaningClick = () => {
     setShowCleaningForm((prev) => !prev);
@@ -94,7 +87,6 @@ const SideBar = ({ onButtonClick, onDataCleaned,
     ? Object.keys(parsedDataPreview[0])
     : [];
 
-console.log("Extracted fields:", fields);
 
   return (
     <div className="sidebar-container">
@@ -132,7 +124,6 @@ console.log("Extracted fields:", fields);
         onClick={() => {
           setShowRawViewer(true);        // new feature
           setShowDataViewerOptions(false);
-          console.log('clicked raw → calling', setShowRawViewer(true))
         }}
       >
         <BiSpreadsheet className="sidebar-button-icon" />


### PR DESCRIPTION
## Summary
- ensure API and database data handlers populate full and cleaned datasets
- render Raw Data window even when dataset is empty, defaulting to an empty table
- drop leftover sidebar debug logging

## Testing
- `npm test -- --watchAll=false`
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bcf697bcf4832eade6732aa6c97fb8