### PR TITLE
Ensure uploaded files populate full dataset

### DIFF
--- a/frontend/frontend/src/components/FileUpload.jsx
+++ b/frontend/frontend/src/components/FileUpload.jsx
@@ -6,7 +6,7 @@ import { useContext } from 'react';
 
 const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000';
 
-function FileUpload({ label = "Upload a File:", onUploadComplete, allowedExtensions = ['csv', 'xls', 'xlsx', 'json', 'pdf', 'geojson'] }) {
+function FileUpload({ label = "Upload a File:", onUploadComplete, allowedExtensions = ['csv', 'xls', 'xlsx', 'json', 'pdf', 'geojson'], onFileUploadSuccess }) {
   const { setUploadedData } = useContext(DataContext);
   const [file, setFile] = useState(null);
   const [error, setError] = useState(null);
@@ -46,7 +46,9 @@ function FileUpload({ label = "Upload a File:", onUploadComplete, allowedExtensi
       });
 
       setUploadedData(response.data);
-
+      if (onFileUploadSuccess) {
+        onFileUploadSuccess(response.data);
+      }
       if (onUploadComplete) {
         onUploadComplete();
       }

--- a/frontend/frontend/src/components/MenuBar.jsx
+++ b/frontend/frontend/src/components/MenuBar.jsx
@@ -10,7 +10,7 @@ import { DataContext } from '../context/DataContext';
 
 const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000';
 
-function MenuBar({ onStatsSelect, handleApiData, handleDatabaseData, setOpenDataFilter, aiReportReady, onAiReportClick }) {
+function MenuBar({ onFileUploadSuccess, onStatsSelect, handleApiData, handleDatabaseData, setOpenDataFilter, aiReportReady, onAiReportClick }) {
   const [activeDropdown, setActiveDropdown] = useState(null);
   const { setUploadedData } = useContext(DataContext);
 
@@ -53,6 +53,9 @@ function MenuBar({ onStatsSelect, handleApiData, handleDatabaseData, setOpenData
       const response = await axios.post(`${API_URL}/api/upload`, formData);
       console.log('Backend response:', response.data);
       setUploadedData(response.data);
+      if (onFileUploadSuccess) {
+        onFileUploadSuccess(response.data);
+      }
       setActiveDropdown(null);
     } catch (error) {
       console.error('File upload error:', error);
@@ -79,7 +82,11 @@ function MenuBar({ onStatsSelect, handleApiData, handleDatabaseData, setOpenData
           </button>
           {activeDropdown === 'upload' && (
             <div className="menu-dropdown">
-              <FileUpload label="Select a File to Upload:" onUploadComplete={() => setActiveDropdown(null)} />
+              <FileUpload
+                label="Select a File to Upload:"
+                onUploadComplete={() => setActiveDropdown(null)}
+                onFileUploadSuccess={onFileUploadSuccess}
+              />
               <DragDrop onFilesSelected={handleFileUpload} width="100%" height="200px" />
             </div>
           )}


### PR DESCRIPTION
## Summary
- Wire file uploads to App's handler so full dataset updates
- Invoke upload callback from FileUpload and MenuBar

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68be52630f40832ea593c6f2a7ebe3e6