### PR TITLE
Add workflow save and load functionality

### DIFF
--- a/frontend/frontend/src/components/css/workflow_lab_css/AiWorkflowLab.css
+++ b/frontend/frontend/src/components/css/workflow_lab_css/AiWorkflowLab.css
@@ -9,6 +9,59 @@
   font-family: "Segoe UI", Roboto, sans-serif;
 }
 
+.workflow-lab-toolbar {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  display: flex;
+  gap: 12px;
+  z-index: 10;
+  background: rgba(255, 255, 255, 0.92);
+  padding: 8px 12px;
+  border-radius: 12px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.12);
+  backdrop-filter: blur(6px);
+}
+
+.workflow-toolbar-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: 8px;
+  border: none;
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.3s ease;
+  box-shadow: 0 6px 15px rgba(37, 99, 235, 0.3);
+}
+
+.workflow-toolbar-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 25px rgba(37, 99, 235, 0.45);
+}
+
+.workflow-toolbar-button:focus-visible {
+  outline: 2px solid #bfdbfe;
+  outline-offset: 3px;
+}
+
+.workflow-toolbar-button svg {
+  width: 18px;
+  height: 18px;
+}
+
+.workflow-toolbar-file-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  width: 0;
+  height: 0;
+}
+
 .icon-node {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- add export helper and toolbar controls so workflows can be saved to timestamped JSON files
- support importing workflow specs with validation, resetting pipeline results, and preserving node params/types
- style new save/load buttons with floating toolbar treatment for consistent UI

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5ef9fc0f0832e918788aaacd15557