### PR TITLE
Fix DataStoryPanel story model propagation and Gemini endpoints

### DIFF
--- a/backend/services/ai_logic_gemini.py
+++ b/backend/services/ai_logic_gemini.py
@@ -5,19 +5,18 @@ import textwrap  # For dedenting multi-line strings
 import google.generativeai as genai # Import Google Generative AI library
 
 # Configure the Google Generative AI library with API key from environment variable
-api_key = os.getenv("GEMINI_API_KEY")  # Ensure this says GEMINI_API_KEY
+api_key = os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
 if not api_key:
     # Make sure the error message also reflects the correct variable name
-    raise ValueError("GEMINI_API_KEY is not set in the environment variables.")
+    raise ValueError("Neither GEMINI_API_KEY nor GOOGLE_API_KEY is set in the environment variables.")
 genai.configure(api_key=api_key)
 
 # Define Flask Blueprint for AI-related routes
 ai_gemini_bp = Blueprint("ai_gemini_bp", __name__)
 
 # --- Model Configuration ---
-# Choose a Gemini model. 'gemini-1.5-flash' is often a good balance of speed and capability.
-# You could also use 'gemini-pro'.
-GEMINI_MODEL_NAME = 'gemini-2.5-flash-lite' # Or 'gemini-pro'
+# Choose a Gemini model. 'gemini-pro' is a widely available general-purpose model.
+GEMINI_MODEL_NAME = 'gemini-pro'
 # Generation configuration for Gemini (maps roughly to OpenAI parameters)
 # Note: Direct equivalents for frequency_penalty/presence_penalty aren't standard.
 # Safety settings can be added if needed.

--- a/backend/services/ai_storyboard_gemini.py
+++ b/backend/services/ai_storyboard_gemini.py
@@ -8,8 +8,11 @@ import google.generativeai as genai
 ai_storyboard_gemini = Blueprint("ai_storyboard_gemini", __name__)
 
 # ─── Gemini init ────────────────────────────────────────────────────────────
-genai.configure(api_key=os.getenv("GEMINI_API_KEY"))
-gemini = genai.GenerativeModel("gemini-1.5-flash")
+_gemini_api_key = os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
+if not _gemini_api_key:
+    raise ValueError("Neither GEMINI_API_KEY nor GOOGLE_API_KEY is set for Gemini storyboard support.")
+genai.configure(api_key=_gemini_api_key)
+gemini = genai.GenerativeModel("gemini-pro")
 
 # ─── Helpers ────────────────────────────────────────────────────────────────
 def normalise_dataset(payload):
@@ -44,7 +47,7 @@ def gemini_call(prompt):
     return resp.text.strip()
 
 # ─── Route ───────────────────────────────────────────────────────────────────
-@ai_storyboard_gemini.route("/api/storyboard", methods=["POST"])
+@ai_storyboard_gemini.route("/api/storyboard-gemini", methods=["POST"])
 def storyboard():
     try:
         body = request.get_json(silent=True) or {}

--- a/frontend/frontend/src/App.jsx
+++ b/frontend/frontend/src/App.jsx
@@ -426,9 +426,10 @@ const handleFileUpload = useCallback((raw, file = null) => {
                 setOutputWindows={setOutputWindows}
                 showAiReport={showAiReport}
                 onCloseAiReport={handleAiReportClose}
+                storyModel={storyModel}
                 showRawViewer={showRawViewer}
                 handleCloseRawViewer={handleCloseRawViewer}
-            
+
               >
                 {/* ⬇️ Keep other children that should render inside the Data Preview window */}
                 <DatasetInfo selectedStat={selectedStat} />


### PR DESCRIPTION
## Summary
- pass the selected story model from App into CanvasContainer so DataStoryPanel receives it
- update Gemini service configuration to use the current gemini-pro model and fall back to GOOGLE_API_KEY when needed
- expose a /api/storyboard-gemini route backed by the gemini storyboard service to match the frontend routing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8a5b9b1a8832eac5ab01d155ba399