### PR TITLE
Enhance decision semantics and unify PDF export functionality

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Do not scan every Markdown file. Do not scan `project_docs/archive/` unless an a
 | Understand current truth and scan rules | `project_docs/active/README.md` |
 | Check current Decision Intelligence status | `project_docs/active/status/decision_intelligence_execution_status.md` |
 | Confirm Codex vs Gemini ownership | `project_docs/active/rules/CODEX_FRONTEND_GUARDRAIL_READ_FIRST.md` |
-| Execute the current implementation plan | `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md` |
+| Execute the current implementation plan | `project_docs/active/pdf_export_unification_plan.md` |
 | Review the council-derived roadmap | `project_docs/active/decision_intelligence/current/next_focus_execution_plan.md` |
 | Choose next implementation work | `project_docs/active/agent_council/outputs/application-next-focus-priorities/README.md` |
 | Inspect detailed next-focus recommendations | `project_docs/active/agent_council/outputs/application-next-focus-priorities/2026-05-01-council.json` |
@@ -20,7 +20,7 @@ Do not scan every Markdown file. Do not scan `project_docs/archive/` unless an a
 | Work on Decision Intelligence historical plans or handoffs | `project_docs/active/decision_intelligence/README.md` first |
 | Run or update Agent Council workflow | `project_docs/active/agent_council/README.md` |
 
-Current project truth: Decision Intelligence V3 is active. Phase 4.5 hardening, Phase 1 reliability foundation, and Phase 2 semantic role strengthening are complete as backend foundations. The active next implementation plan is Codex-owned Phase 3 correction and ranked observational evidence at `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md`. Frontend implementation belongs to Gemini unless the user explicitly authorizes Codex frontend edits in the current session.
+Current project truth: Decision Intelligence V3 is active. Phase 4.5 hardening and Phase 1 reliability foundation are complete. Phase 2 semantic metadata plumbing is implemented, but May 14 PDF review showed the active prompt-first decision frame still drops or misclassifies key semantic roles. Before Phase 2.5 continues, the active next implementation plan is app-wide PDF export unification at `project_docs/active/pdf_export_unification_plan.md`, because exports must accurately match visible app content for reliable review. Phase 2.5 semantic frame completion is next after PDF export unification. Phase 3 correction and ranked observational evidence is deferred until Phase 2.5 is complete. Frontend implementation belongs to Gemini unless the user explicitly authorizes Codex frontend edits in the current session; the PDF export branch prompt explicitly authorizes Codex to work on the export UI and frontend export code.
 
 Codex is the coordinator for Decision Intelligence work. This file is only for standing Codex reference, not for active Gemini task handoffs.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Do not scan every Markdown file. Do not scan `project_docs/archive/` unless an a
 | Understand current truth and scan rules | `project_docs/active/README.md` |
 | Check current Decision Intelligence status | `project_docs/active/status/decision_intelligence_execution_status.md` |
 | Confirm Codex vs Gemini ownership | `project_docs/active/rules/CODEX_FRONTEND_GUARDRAIL_READ_FIRST.md` |
-| Execute the current implementation plan | `project_docs/active/decision_intelligence/current/phase_2_semantic_role_strengthening_plan.md` |
+| Execute the current implementation plan | `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md` |
 | Review the council-derived roadmap | `project_docs/active/decision_intelligence/current/next_focus_execution_plan.md` |
 | Choose next implementation work | `project_docs/active/agent_council/outputs/application-next-focus-priorities/README.md` |
 | Inspect detailed next-focus recommendations | `project_docs/active/agent_council/outputs/application-next-focus-priorities/2026-05-01-council.json` |
@@ -20,7 +20,7 @@ Do not scan every Markdown file. Do not scan `project_docs/archive/` unless an a
 | Work on Decision Intelligence historical plans or handoffs | `project_docs/active/decision_intelligence/README.md` first |
 | Run or update Agent Council workflow | `project_docs/active/agent_council/README.md` |
 
-Current project truth: Decision Intelligence V3 is active. Phase 4.5 hardening and Phase 1 reliability foundation are complete, including Gemini frontend integration of the reliability fields. The active next implementation plan is Codex-owned Phase 2 semantic role strengthening at `project_docs/active/decision_intelligence/current/phase_2_semantic_role_strengthening_plan.md`. Frontend implementation belongs to Gemini unless the user explicitly authorizes Codex frontend edits in the current session.
+Current project truth: Decision Intelligence V3 is active. Phase 4.5 hardening, Phase 1 reliability foundation, and Phase 2 semantic role strengthening are complete as backend foundations. The active next implementation plan is Codex-owned Phase 3 correction and ranked observational evidence at `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md`. Frontend implementation belongs to Gemini unless the user explicitly authorizes Codex frontend edits in the current session.
 
 Codex is the coordinator for Decision Intelligence work. This file is only for standing Codex reference, not for active Gemini task handoffs.
 

--- a/backend/services/decision_support.py
+++ b/backend/services/decision_support.py
@@ -197,7 +197,7 @@ def build_semantic_summary(semantic_model: Dict[str, Any]) -> Dict[str, Any]:
 def build_metric_ref(metric: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
     if not isinstance(metric, dict):
         return None
-    return {
+    ref = {
         "metric_id": metric.get("id") or metric.get("metric_id"),
         "name": metric.get("name") or metric.get("label") or metric.get("display_name"),
         "label": metric.get("label") or metric.get("display_name") or metric.get("name"),
@@ -205,12 +205,15 @@ def build_metric_ref(metric: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any
         "default_aggregation": metric.get("default_aggregation"),
         "format_hint": metric.get("format_hint"),
     }
+    if isinstance(metric.get("decision_semantics"), dict):
+        ref["decision_semantics"] = metric["decision_semantics"]
+    return ref
 
 
 def build_dimension_ref(dimension: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
     if not isinstance(dimension, dict):
         return None
-    return {
+    ref = {
         "dimension_id": dimension.get("id"),
         "name": dimension.get("name") or dimension.get("field"),
         "label": dimension.get("label") or dimension.get("field"),
@@ -218,6 +221,9 @@ def build_dimension_ref(dimension: Optional[Dict[str, Any]]) -> Optional[Dict[st
         "semantic_kind": dimension.get("semantic_kind"),
         "data_type": dimension.get("data_type"),
     }
+    if isinstance(dimension.get("decision_semantics"), dict):
+        ref["decision_semantics"] = dimension["decision_semantics"]
+    return ref
 
 
 def build_field_profile_map(context: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:

--- a/backend/services/decision_workspace_service.py
+++ b/backend/services/decision_workspace_service.py
@@ -392,6 +392,75 @@ class DecisionWorkspaceService:
         return {
             "metrics": metric_matches[:5],
             "dimensions": dimension_matches[:4],
+            "unresolved_mappings": DecisionWorkspaceService._build_prompt_unresolved_mappings(
+                text_blob=text_blob,
+                metric_matches=metric_matches,
+                dimension_matches=dimension_matches,
+            ),
+        }
+
+    @staticmethod
+    def _build_prompt_unresolved_mappings(
+        text_blob: str,
+        metric_matches: Sequence[Dict[str, Any]],
+        dimension_matches: Sequence[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        unresolved: List[Dict[str, Any]] = []
+        if text_blob and not metric_matches:
+            unresolved.append({
+                "mapping_type": "metric",
+                "status": "unresolved",
+                "reason": "No metric matched the prompt with safe confidence.",
+                "candidate_labels": [],
+            })
+        metric_ambiguity = DecisionWorkspaceService._detect_prompt_ambiguity(metric_matches, "metric")
+        if metric_ambiguity:
+            unresolved.append(metric_ambiguity)
+        dimension_ambiguity = DecisionWorkspaceService._detect_prompt_ambiguity(dimension_matches, "dimension")
+        if dimension_ambiguity:
+            unresolved.append(dimension_ambiguity)
+        return unresolved
+
+    @staticmethod
+    def _detect_prompt_ambiguity(
+        matches: Sequence[Dict[str, Any]],
+        mapping_type: str,
+    ) -> Optional[Dict[str, Any]]:
+        if len(matches) < 2:
+            return None
+        for first_index, first in enumerate(matches):
+            for second in matches[first_index + 1:]:
+                first_confidence = float(first.get("semantic_binding_confidence") or 0.0)
+                second_confidence = float(second.get("semantic_binding_confidence") or 0.0)
+                first_tokens = DecisionWorkspaceService._salient_ref_tokens(first)
+                second_tokens = DecisionWorkspaceService._salient_ref_tokens(second)
+                if abs(first_confidence - second_confidence) <= 0.08 and first_tokens.intersection(second_tokens):
+                    return {
+                        "mapping_type": mapping_type,
+                        "status": "ambiguous",
+                        "reason": "Multiple semantic objects matched the prompt with similar confidence.",
+                        "candidate_labels": [
+                            str(first.get("label") or first.get("name") or "").strip(),
+                            str(second.get("label") or second.get("name") or "").strip(),
+                        ],
+                        "confidence": round(max(first_confidence, second_confidence), 2),
+                    }
+        return None
+
+    @staticmethod
+    def _salient_ref_tokens(ref: Dict[str, Any]) -> set:
+        tokens: List[str] = []
+        for key in ("label", "name", "field"):
+            normalized_value = DecisionWorkspaceService._normalize_phrase(ref.get(key))
+            tokens.extend(
+                DecisionWorkspaceService._normalize_prompt_token(token)
+                for token in normalized_value.split()
+                if token not in DecisionWorkspaceService.PROMPT_MATCH_STOPWORDS
+            )
+        return {
+            token
+            for token in tokens
+            if token and token not in DecisionWorkspaceService.GENERIC_METRIC_TOKENS
         }
 
     @staticmethod
@@ -431,7 +500,22 @@ class DecisionWorkspaceService:
             score = DecisionWorkspaceService._score_prompt_candidate(candidate, tokens, normalized_blob)
             if score <= 0:
                 continue
-            ranked.append((score, ref_builder(candidate)))
+            ref = ref_builder(candidate)
+            if not isinstance(ref, dict):
+                continue
+            ref["semantic_binding_confidence"] = DecisionWorkspaceService._semantic_binding_confidence(score, ref, None)
+            ref["semantic_binding_reason"] = (
+                ((ref.get("decision_semantics") or {}).get("confidence_reason"))
+                if isinstance(ref.get("decision_semantics"), dict)
+                else "Lexical prompt evidence matched this semantic object."
+            )
+            ref["semantic_role_source"] = "decision_semantics" if isinstance(ref.get("decision_semantics"), dict) else "lexical_match"
+            ref["semantic_role_warnings"] = list(
+                ((ref.get("decision_semantics") or {}).get("unresolved_reasons") or [])
+                if isinstance(ref.get("decision_semantics"), dict)
+                else []
+            )
+            ranked.append((score, ref))
 
         ranked.sort(
             key=lambda item: (
@@ -461,6 +545,20 @@ class DecisionWorkspaceService:
             candidate_tokens.extend(value_tokens)
             if normalized_value in normalized_blob:
                 score += 6 + len(value_tokens)
+
+        semantics = candidate.get("decision_semantics") if isinstance(candidate.get("decision_semantics"), dict) else {}
+        for alias in list(semantics.get("aliases") or []) + list(semantics.get("business_terms") or []):
+            normalized_alias = DecisionWorkspaceService._normalize_phrase(alias)
+            if not normalized_alias:
+                continue
+            alias_tokens = [
+                DecisionWorkspaceService._normalize_prompt_token(token)
+                for token in normalized_alias.split()
+                if token not in DecisionWorkspaceService.PROMPT_MATCH_STOPWORDS
+            ]
+            candidate_tokens.extend(alias_tokens)
+            if normalized_alias in normalized_blob:
+                score += 4 + len(alias_tokens)
 
         if not candidate_tokens:
             return score
@@ -537,6 +635,7 @@ class DecisionWorkspaceService:
         objective_metric = DecisionWorkspaceService._find_best_prompt_metric_match(
             objective_text,
             prompt_matches.get("metrics") or [],
+            role="objective",
         )
         direction = DecisionWorkspaceService._infer_objective_direction(objective_text or decision_prompt)
 
@@ -558,6 +657,7 @@ class DecisionWorkspaceService:
             "metric_id": objective_metric.get("metric_id") if objective_metric else None,
             "direction": direction,
             "time_horizon": prompt_frame.get("time_horizon"),
+            **DecisionWorkspaceService._semantic_trace_from_ref(objective_metric),
         }
 
     @staticmethod
@@ -583,6 +683,7 @@ class DecisionWorkspaceService:
         ranked_metric_refs = DecisionWorkspaceService._rank_prompt_refs(
             lever_text,
             prompt_matches.get("metrics") or [],
+            role="lever",
         )
 
         for metric_ref in ranked_metric_refs:
@@ -594,7 +695,10 @@ class DecisionWorkspaceService:
                 {
                     "label": label,
                     "lever_type": DecisionWorkspaceService._infer_lever_type(label),
-                    "binding": {"metric_id": metric_id},
+                    "binding": {
+                        "metric_id": metric_id,
+                        **DecisionWorkspaceService._semantic_trace_from_ref(metric_ref),
+                    },
                     "desired_change": DecisionWorkspaceService._infer_desired_change(text_blob),
                 }
             )
@@ -610,6 +714,7 @@ class DecisionWorkspaceService:
             ranked_dimension_refs = DecisionWorkspaceService._rank_prompt_refs(
                 lever_and_segment_text,
                 prompt_matches.get("dimensions") or [],
+                role="segment",
             )
             for dimension_ref in ranked_dimension_refs:
                 dimension_id = dimension_ref.get("dimension_id")
@@ -619,7 +724,10 @@ class DecisionWorkspaceService:
                     {
                         "label": f"{dimension_ref.get('label') or dimension_ref.get('name')} mix",
                         "lever_type": "mix",
-                        "binding": {"dimension_id": dimension_id},
+                        "binding": {
+                            "dimension_id": dimension_id,
+                            **DecisionWorkspaceService._semantic_trace_from_ref(dimension_ref),
+                        },
                         "desired_change": "shift",
                     }
                 )
@@ -642,6 +750,7 @@ class DecisionWorkspaceService:
             metric_ref = DecisionWorkspaceService._find_best_prompt_metric_match(
                 clause,
                 prompt_matches.get("metrics") or [],
+                role="guardrail",
             )
             metric_id = metric_ref.get("metric_id") if isinstance(metric_ref, dict) else None
             if not metric_id or metric_id in used_metric_ids:
@@ -659,7 +768,10 @@ class DecisionWorkspaceService:
                     "label": f"Protect {metric_ref.get('label') or metric_ref.get('name')}",
                     "description": clause,
                     "constraint_type": "metric_guardrail",
-                    "binding": {"metric_id": metric_id},
+                    "binding": {
+                        "metric_id": metric_id,
+                        **DecisionWorkspaceService._semantic_trace_from_ref(metric_ref),
+                    },
                     "condition": {
                         "operator": operator,
                         "value": None,
@@ -921,17 +1033,24 @@ class DecisionWorkspaceService:
     def _rank_prompt_refs(
         text: str,
         refs: Sequence[Dict[str, Any]],
+        role: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         tokens = DecisionWorkspaceService._tokenize_prompt_text(text)
         normalized_text = DecisionWorkspaceService._normalize_phrase(text)
-        ranked: List[Tuple[int, Dict[str, Any]]] = []
+        ranked: List[Tuple[float, Dict[str, Any]]] = []
         for ref in refs:
             if not DecisionWorkspaceService._has_strong_ref_evidence(text, ref):
                 continue
             score = DecisionWorkspaceService._score_prompt_candidate(ref, tokens, normalized_text)
             if score <= 0:
                 continue
-            ranked.append((score, ref))
+            confidence = DecisionWorkspaceService._semantic_binding_confidence(score, ref, role)
+            if confidence < 0.58:
+                continue
+            ranked.append((
+                score + DecisionWorkspaceService._semantic_role_weight(ref, role),
+                DecisionWorkspaceService._annotate_semantic_binding(ref, role, confidence, "resolved"),
+            ))
         ranked.sort(
             key=lambda item: (
                 -item[0],
@@ -949,6 +1068,12 @@ class DecisionWorkspaceService:
         for key in ("label", "name", "field"):
             normalized_value = DecisionWorkspaceService._normalize_phrase(ref.get(key))
             if normalized_value and normalized_value in normalized_text:
+                return True
+
+        semantics = ref.get("decision_semantics") if isinstance(ref.get("decision_semantics"), dict) else {}
+        for alias in list(semantics.get("aliases") or []) + list(semantics.get("business_terms") or []):
+            normalized_alias = DecisionWorkspaceService._normalize_phrase(alias)
+            if normalized_alias and normalized_alias in normalized_text:
                 return True
 
         text_tokens = set(DecisionWorkspaceService._tokenize_prompt_text(text))
@@ -970,37 +1095,150 @@ class DecisionWorkspaceService:
     def _find_best_prompt_metric_match(
         text: str,
         metric_refs: Sequence[Dict[str, Any]],
+        role: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         text_tokens = DecisionWorkspaceService._tokenize_prompt_text(text)
         normalized_text = DecisionWorkspaceService._normalize_phrase(text)
-        best_score = 0
-        best_match: Optional[Dict[str, Any]] = None
+        ranked: List[Tuple[float, float, Dict[str, Any]]] = []
         for metric_ref in metric_refs:
             if not DecisionWorkspaceService._has_strong_ref_evidence(text, metric_ref):
                 continue
             score = DecisionWorkspaceService._score_prompt_candidate(metric_ref, text_tokens, normalized_text)
-            if score > best_score:
-                best_score = score
-                best_match = metric_ref
-        return best_match
+            confidence = DecisionWorkspaceService._semantic_binding_confidence(score, metric_ref, role)
+            if confidence < 0.58:
+                continue
+            ranked.append((score + DecisionWorkspaceService._semantic_role_weight(metric_ref, role), confidence, metric_ref))
+        return DecisionWorkspaceService._select_prompt_match(ranked, role)
 
     @staticmethod
     def _find_best_prompt_dimension_match(
         text: str,
         dimension_refs: Sequence[Dict[str, Any]],
+        role: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         text_tokens = DecisionWorkspaceService._tokenize_prompt_text(text)
         normalized_text = DecisionWorkspaceService._normalize_phrase(text)
-        best_score = 0
-        best_match: Optional[Dict[str, Any]] = None
+        ranked: List[Tuple[float, float, Dict[str, Any]]] = []
         for dimension_ref in dimension_refs:
             if not DecisionWorkspaceService._has_strong_ref_evidence(text, dimension_ref):
                 continue
             score = DecisionWorkspaceService._score_prompt_candidate(dimension_ref, text_tokens, normalized_text)
-            if score > best_score:
-                best_score = score
-                best_match = dimension_ref
-        return best_match
+            confidence = DecisionWorkspaceService._semantic_binding_confidence(score, dimension_ref, role)
+            if confidence < 0.58:
+                continue
+            ranked.append((score + DecisionWorkspaceService._semantic_role_weight(dimension_ref, role), confidence, dimension_ref))
+        return DecisionWorkspaceService._select_prompt_match(ranked, role)
+
+    @staticmethod
+    def _select_prompt_match(
+        ranked: Sequence[Tuple[float, float, Dict[str, Any]]],
+        role: Optional[str],
+    ) -> Optional[Dict[str, Any]]:
+        if not ranked:
+            return None
+        ordered = sorted(
+            ranked,
+            key=lambda item: (
+                -item[0],
+                str(item[2].get("label") or item[2].get("name") or ""),
+            ),
+        )
+        best_score, best_confidence, best_ref = ordered[0]
+        if len(ordered) > 1 and abs(best_score - ordered[1][0]) <= 1.5:
+            return None
+        return DecisionWorkspaceService._annotate_semantic_binding(best_ref, role, best_confidence, "resolved")
+
+    @staticmethod
+    def _semantic_binding_confidence(score: int, ref: Dict[str, Any], role: Optional[str]) -> float:
+        semantics = ref.get("decision_semantics") if isinstance(ref.get("decision_semantics"), dict) else {}
+        semantic_confidence = float(semantics.get("confidence") or 0.5)
+        lexical_confidence = min(0.35, max(score, 0) / 45)
+        role_weight = DecisionWorkspaceService._semantic_role_weight(ref, role) / 20
+        confidence = 0.32 + lexical_confidence + role_weight
+        confidence = min(confidence, semantic_confidence + 0.12, 0.94)
+        return round(max(confidence, 0.0), 2)
+
+    @staticmethod
+    def _semantic_role_weight(ref: Dict[str, Any], role: Optional[str]) -> float:
+        if not role:
+            return 0.0
+        semantics = ref.get("decision_semantics") if isinstance(ref.get("decision_semantics"), dict) else {}
+        if DecisionWorkspaceService._semantic_role_candidate(ref, role):
+            return 4.0 + (float(semantics.get("confidence") or 0.0) * 2.0)
+        return -0.5
+
+    @staticmethod
+    def _semantic_role_candidate(ref: Dict[str, Any], role: Optional[str]) -> bool:
+        if not role:
+            return True
+        semantics = ref.get("decision_semantics") if isinstance(ref.get("decision_semantics"), dict) else {}
+        key_by_role = {
+            "objective": "objective_candidate",
+            "lever": "lever_candidate",
+            "guardrail": "guardrail_candidate",
+            "segment": "segment_candidate",
+            "comparison": "comparison_candidate",
+            "temporal": "temporal_candidate",
+        }
+        candidate_key = key_by_role.get(role)
+        if not candidate_key:
+            return True
+        return bool(semantics.get(candidate_key))
+
+    @staticmethod
+    def _annotate_semantic_binding(
+        ref: Dict[str, Any],
+        role: Optional[str],
+        confidence: float,
+        status: str,
+    ) -> Dict[str, Any]:
+        annotated = dict(ref)
+        semantics = ref.get("decision_semantics") if isinstance(ref.get("decision_semantics"), dict) else {}
+        annotated["semantic_binding_confidence"] = round(float(confidence), 2)
+        annotated["semantic_binding_reason"] = semantics.get("confidence_reason") or "Lexical prompt evidence matched this semantic object."
+        annotated["semantic_role_source"] = "decision_semantics" if semantics else "lexical_match"
+        warnings = list(semantics.get("unresolved_reasons") or [])
+        if role and not DecisionWorkspaceService._semantic_role_candidate(ref, role):
+            warnings.append(f"Matched text, but semantic role metadata does not mark this as a {role} candidate.")
+        if status != "resolved":
+            warnings.append(f"Binding status is {status}; review is required before treating it as resolved.")
+        annotated["semantic_role_warnings"] = DecisionWorkspaceService._dedupe_strings(warnings)
+        return annotated
+
+    @staticmethod
+    def _semantic_trace_from_ref(
+        ref: Optional[Dict[str, Any]],
+        fallback: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        source = ref if isinstance(ref, dict) else {}
+        fallback_source = fallback if isinstance(fallback, dict) else {}
+        semantics = source.get("decision_semantics") if isinstance(source.get("decision_semantics"), dict) else {}
+        confidence = (
+            source.get("semantic_binding_confidence")
+            if source.get("semantic_binding_confidence") is not None
+            else fallback_source.get("semantic_binding_confidence")
+        )
+        if confidence is None and semantics:
+            confidence = semantics.get("confidence")
+        reason = (
+            source.get("semantic_binding_reason")
+            or fallback_source.get("semantic_binding_reason")
+            or semantics.get("confidence_reason")
+        )
+        role_source = (
+            source.get("semantic_role_source")
+            or fallback_source.get("semantic_role_source")
+            or ("decision_semantics" if semantics else None)
+        )
+        warnings = list(source.get("semantic_role_warnings") or [])
+        warnings.extend(list(fallback_source.get("semantic_role_warnings") or []))
+        warnings.extend(list(semantics.get("unresolved_reasons") or []))
+        return {
+            "semantic_binding_confidence": round(float(confidence), 2) if confidence is not None else None,
+            "semantic_binding_reason": reason,
+            "semantic_role_source": role_source,
+            "semantic_role_warnings": DecisionWorkspaceService._dedupe_strings(warnings),
+        }
 
     @staticmethod
     def _infer_objective_direction(text: str) -> str:
@@ -1131,6 +1369,7 @@ class DecisionWorkspaceService:
             "prompt_matches": {
                 "metrics": list(prompt_matches.get("metrics") or []),
                 "dimensions": list(prompt_matches.get("dimensions") or []),
+                "unresolved_mappings": list(prompt_matches.get("unresolved_mappings") or []),
             },
             "clarification_hints": list(DecisionWorkspaceService._dedupe_strings(clarification_hints)),
             "prompt_frame": prompt_frame or {},
@@ -1162,6 +1401,7 @@ class DecisionWorkspaceService:
             "prompt_matches": {
                 "metrics": list(prompt_matches.get("metrics") or []),
                 "dimensions": list(prompt_matches.get("dimensions") or []),
+                "unresolved_mappings": list(prompt_matches.get("unresolved_mappings") or []),
             },
             "clarification_hints": list(raw.get("clarification_hints") or []),
             "prompt_frame": raw.get("prompt_frame") if isinstance(raw.get("prompt_frame"), dict) else {},
@@ -1218,6 +1458,7 @@ class DecisionWorkspaceService:
             "metric_ref": metric_ref,
             "resolution_status": resolution_status,
             "reason": reason,
+            **DecisionWorkspaceService._semantic_trace_from_ref(metric_ref, raw),
         }
 
     @staticmethod
@@ -1354,13 +1595,15 @@ class DecisionWorkspaceService:
         if metric_reference:
             metric = DecisionWorkspaceService._find_metric(context, metric_reference)
             if metric:
+                metric_ref = build_metric_ref(metric)
                 return {
                     "binding_type": "metric",
                     "status": "resolved",
-                    "metric_ref": build_metric_ref(metric),
+                    "metric_ref": metric_ref,
                     "dimension_ref": None,
                     "field": None,
                     "reason": None,
+                    **DecisionWorkspaceService._semantic_trace_from_ref(metric_ref, binding_input),
                 }
             return {
                 "binding_type": "metric",
@@ -1369,18 +1612,24 @@ class DecisionWorkspaceService:
                 "dimension_ref": None,
                 "field": None,
                 "reason": f"Metric '{metric_reference}' was not found in the semantic model.",
+                "semantic_binding_confidence": 0.0,
+                "semantic_binding_reason": f"Metric '{metric_reference}' was not found in the semantic model.",
+                "semantic_role_source": "unresolved",
+                "semantic_role_warnings": ["Metric binding could not be resolved."],
             }
 
         if dimension_reference:
             dimension = DecisionWorkspaceService._find_dimension(context, dimension_reference)
             if dimension:
+                dimension_ref = build_dimension_ref(dimension)
                 return {
                     "binding_type": "dimension",
                     "status": "resolved",
                     "metric_ref": None,
-                    "dimension_ref": build_dimension_ref(dimension),
+                    "dimension_ref": dimension_ref,
                     "field": None,
                     "reason": None,
+                    **DecisionWorkspaceService._semantic_trace_from_ref(dimension_ref, binding_input),
                 }
             return {
                 "binding_type": "dimension",
@@ -1389,29 +1638,37 @@ class DecisionWorkspaceService:
                 "dimension_ref": None,
                 "field": None,
                 "reason": f"Dimension '{dimension_reference}' was not found in the semantic model.",
+                "semantic_binding_confidence": 0.0,
+                "semantic_binding_reason": f"Dimension '{dimension_reference}' was not found in the semantic model.",
+                "semantic_role_source": "unresolved",
+                "semantic_role_warnings": ["Dimension binding could not be resolved."],
             }
 
         if field:
             dimension = DecisionWorkspaceService._find_dimension_by_field(context, field)
             if dimension:
+                dimension_ref = build_dimension_ref(dimension)
                 return {
                     "binding_type": "dimension",
                     "status": "resolved",
                     "metric_ref": None,
-                    "dimension_ref": build_dimension_ref(dimension),
+                    "dimension_ref": dimension_ref,
                     "field": None,
                     "reason": None,
+                    **DecisionWorkspaceService._semantic_trace_from_ref(dimension_ref, binding_input),
                 }
 
             metric = DecisionWorkspaceService._find_metric_by_field(context, field)
             if metric:
+                metric_ref = build_metric_ref(metric)
                 return {
                     "binding_type": "metric",
                     "status": "resolved",
-                    "metric_ref": build_metric_ref(metric),
+                    "metric_ref": metric_ref,
                     "dimension_ref": None,
                     "field": None,
                     "reason": None,
+                    **DecisionWorkspaceService._semantic_trace_from_ref(metric_ref, binding_input),
                 }
 
             if field in {str(column) for column in context["dataframe"].columns}:
@@ -1422,6 +1679,10 @@ class DecisionWorkspaceService:
                     "dimension_ref": None,
                     "field": field,
                     "reason": None,
+                    "semantic_binding_confidence": 0.45,
+                    "semantic_binding_reason": "Resolved only to a raw dataset field, not a semantic metric or dimension.",
+                    "semantic_role_source": "raw_field",
+                    "semantic_role_warnings": ["Raw field binding should be reviewed before treating it as a semantic decision object."],
                 }
 
             return {
@@ -1431,6 +1692,10 @@ class DecisionWorkspaceService:
                 "dimension_ref": None,
                 "field": field,
                 "reason": f"Field '{field}' does not exist in the dataset.",
+                "semantic_binding_confidence": 0.0,
+                "semantic_binding_reason": f"Field '{field}' does not exist in the dataset.",
+                "semantic_role_source": "unresolved",
+                "semantic_role_warnings": ["Field binding could not be resolved."],
             }
 
         return {
@@ -1440,6 +1705,10 @@ class DecisionWorkspaceService:
             "dimension_ref": None,
             "field": None,
             "reason": "No binding was provided.",
+            "semantic_binding_confidence": 0.0,
+            "semantic_binding_reason": "No binding was provided.",
+            "semantic_role_source": "unresolved",
+            "semantic_role_warnings": ["No semantic binding evidence was available."],
         }
 
     @staticmethod

--- a/backend/services/semantic_model.py
+++ b/backend/services/semantic_model.py
@@ -14,6 +14,52 @@ RATE_KEYWORDS = ("rate", "ratio", "pct", "percent", "average", "avg", "mean")
 CURRENCY_KEYWORDS = ("revenue", "sales", "amount", "cost", "price", "profit", "income", "spend")
 IDENTIFIER_KEYWORDS = ("id", "key", "code", "uuid", "identifier")
 TEMPORAL_KEYWORDS = ("date", "time", "timestamp", "year", "month", "day", "week", "quarter")
+OBJECTIVE_KEYWORDS = (
+    "revenue",
+    "sales",
+    "profit",
+    "margin",
+    "growth",
+    "delivery",
+    "retention",
+    "conversion",
+    "satisfaction",
+    "score",
+    "risk",
+    "return",
+    "stockout",
+    "cost",
+)
+LEVER_KEYWORDS = (
+    "spend",
+    "discount",
+    "price",
+    "budget",
+    "inventory",
+    "capacity",
+    "staffing",
+    "headcount",
+    "allocation",
+    "mix",
+    "promotion",
+    "campaign",
+)
+GUARDRAIL_KEYWORDS = (
+    "margin",
+    "risk",
+    "rate",
+    "cost",
+    "delivery",
+    "return",
+    "stockout",
+    "quality",
+    "sla",
+    "compliance",
+    "churn",
+)
+POSITIVE_POLARITY_KEYWORDS = ("revenue", "sales", "profit", "margin", "delivery", "retention", "conversion", "satisfaction")
+NEGATIVE_POLARITY_KEYWORDS = ("cost", "spend", "discount", "risk", "return", "churn", "stockout", "defect", "delay")
+GRAIN_KEYWORDS = ("day", "week", "month", "quarter", "year")
 SUPPORTED_AGGREGATIONS = {"sum", "avg", "average", "mean", "min", "max", "count", "count_distinct", "distinct_count", "nunique"}
 SUPPORTED_FORMAT_HINTS = {None, "", "number", "currency", "percentage", "date"}
 FORMULA_COLUMN_PATTERN = re.compile(r"\[([^\]]+)\]")
@@ -181,6 +227,12 @@ def finalize_semantic_model(semantic_model: Optional[Dict[str, Any]]) -> Dict[st
         "notes": "The semantic model is additive and does not replace the existing dataset pipeline.",
         **(model.get("compatibility") if isinstance(model.get("compatibility"), dict) else {}),
     }
+
+    normalized_dimensions = []
+    for dimension in model.get("dimensions") if isinstance(model.get("dimensions"), list) else []:
+        if isinstance(dimension, dict):
+            normalized_dimensions.append(_normalize_existing_dimension(dimension, timestamp))
+    model["dimensions"] = normalized_dimensions
 
     normalized_metrics = []
     for metric in model.get("metrics") if isinstance(model.get("metrics"), list) else []:
@@ -387,7 +439,7 @@ def build_user_metric_definition(
 
     created_at = existing_metric.get("created_at") if isinstance(existing_metric, dict) else timestamp
 
-    return {
+    metric = {
         "id": metric_id,
         "metric_id": metric_id,
         "name": name,
@@ -410,9 +462,20 @@ def build_user_metric_definition(
         "origin": "user_defined",
         "is_inferred": False,
         "is_user_defined": True,
+        "decision_semantics": deepcopy(
+            payload.get("decision_semantics")
+            if isinstance(payload.get("decision_semantics"), dict)
+            else (
+                existing_metric.get("decision_semantics")
+                if isinstance(existing_metric, dict) and isinstance(existing_metric.get("decision_semantics"), dict)
+                else {}
+            )
+        ),
         "created_at": created_at,
         "updated_at": timestamp,
     }
+    metric["decision_semantics"] = _build_metric_decision_semantics(metric)
+    return metric
 
 
 def merge_user_defined_metrics(
@@ -577,7 +640,7 @@ def _build_dimension_definition(
     entity_id: str,
     timestamp: str,
 ) -> Dict[str, Any]:
-    return {
+    dimension = {
         "id": f"dimension_{_slugify(column_name)}",
         "name": column_name,
         "label": column_name,
@@ -592,6 +655,8 @@ def _build_dimension_definition(
         "created_at": timestamp,
         "updated_at": timestamp,
     }
+    dimension["decision_semantics"] = _build_dimension_decision_semantics(dimension)
+    return dimension
 
 
 def _build_metric_definition(
@@ -603,7 +668,7 @@ def _build_metric_definition(
     aggregation = profile.get("default_aggregation") or "sum"
     metric_id = f"metric_{_slugify(column_name)}_{aggregation}"
     format_hint = profile.get("format_hint")
-    return {
+    metric = {
         "id": metric_id,
         "metric_id": metric_id,
         "name": column_name,
@@ -636,6 +701,8 @@ def _build_metric_definition(
         "created_at": timestamp,
         "updated_at": timestamp,
     }
+    metric["decision_semantics"] = _build_metric_decision_semantics(metric)
+    return metric
 
 
 def _available_columns(semantic_model: Dict[str, Any], dataframe: Optional[pd.DataFrame]) -> Set[str]:
@@ -744,7 +811,195 @@ def _normalize_existing_metric(metric: Dict[str, Any], fallback_timestamp: str) 
     metric_copy["filters"] = metric_copy.get("filters") if isinstance(metric_copy.get("filters"), list) else (
         metric_copy["expression"].get("filters") if isinstance(metric_copy["expression"].get("filters"), list) else []
     )
+    metric_copy["decision_semantics"] = _build_metric_decision_semantics(metric_copy)
     return metric_copy
+
+
+def _normalize_existing_dimension(dimension: Dict[str, Any], fallback_timestamp: str) -> Dict[str, Any]:
+    dimension_copy = deepcopy(dimension)
+    dimension_copy["id"] = dimension_copy.get("id") or dimension_copy.get("dimension_id") or f"dimension_{_slugify(dimension_copy.get('name') or dimension_copy.get('field') or 'dimension')}"
+    dimension_copy["dimension_id"] = dimension_copy["id"]
+    dimension_copy["name"] = dimension_copy.get("name") or dimension_copy.get("label") or dimension_copy.get("field") or dimension_copy["id"]
+    dimension_copy["label"] = dimension_copy.get("label") or dimension_copy["name"]
+    dimension_copy["field"] = dimension_copy.get("field") or dimension_copy["name"]
+    dimension_copy["semantic_kind"] = dimension_copy.get("semantic_kind") or "categorical"
+    dimension_copy["data_type"] = dimension_copy.get("data_type")
+    dimension_copy["status"] = dimension_copy.get("status") or ("inferred" if dimension_copy.get("is_inferred") else "configured")
+    dimension_copy["is_inferred"] = bool(dimension_copy.get("is_inferred") or dimension_copy["status"] == "inferred")
+    dimension_copy["created_at"] = dimension_copy.get("created_at") or fallback_timestamp
+    dimension_copy["updated_at"] = dimension_copy.get("updated_at") or fallback_timestamp
+    dimension_copy["decision_semantics"] = _build_dimension_decision_semantics(dimension_copy)
+    return dimension_copy
+
+
+def _build_metric_decision_semantics(metric: Dict[str, Any]) -> Dict[str, Any]:
+    existing = metric.get("decision_semantics") if isinstance(metric.get("decision_semantics"), dict) else {}
+    text = _semantic_text(metric, ("id", "metric_id", "name", "label", "display_name", "field", "description"))
+    aliases = _semantic_aliases(metric, ("name", "label", "display_name", "field"))
+    objective_hits = _matched_keywords(text, OBJECTIVE_KEYWORDS)
+    lever_hits = _matched_keywords(text, LEVER_KEYWORDS)
+    guardrail_hits = _matched_keywords(text, GUARDRAIL_KEYWORDS)
+    format_hint = str(metric.get("format_hint") or "").strip().lower()
+    aggregation = str(metric.get("default_aggregation") or metric.get("aggregation_behavior") or "").strip().lower()
+
+    objective_score = 0.2
+    lever_score = 0.2
+    guardrail_score = 0.2
+    evidence: List[str] = []
+
+    if objective_hits:
+        objective_score += 0.45
+        evidence.append(f"objective keywords: {', '.join(objective_hits[:3])}")
+    if format_hint == "currency" and aggregation in {"sum", "avg", "average", "mean"}:
+        objective_score += 0.12
+        evidence.append("business metric format and aggregation")
+    if lever_hits:
+        lever_score += 0.5
+        evidence.append(f"controllable lever keywords: {', '.join(lever_hits[:3])}")
+    if guardrail_hits:
+        guardrail_score += 0.45
+        evidence.append(f"guardrail keywords: {', '.join(guardrail_hits[:3])}")
+    if format_hint == "percentage":
+        guardrail_score += 0.08
+        evidence.append("percentage metric often acts as a threshold or guardrail")
+
+    confidence = round(min(max(objective_score, lever_score, guardrail_score), 0.9), 2)
+    objective_candidate = objective_score >= 0.62
+    lever_candidate = lever_score >= 0.62
+    guardrail_candidate = guardrail_score >= 0.62
+    unresolved_reasons: List[str] = []
+    if confidence < 0.55:
+        unresolved_reasons.append("No strong business-role evidence was found for this metric.")
+    if sum([objective_candidate, lever_candidate, guardrail_candidate]) > 1:
+        unresolved_reasons.append("Multiple plausible decision roles were detected; prompt context should choose the role.")
+
+    inferred = {
+        "objective_candidate": objective_candidate,
+        "lever_candidate": lever_candidate,
+        "guardrail_candidate": guardrail_candidate,
+        "polarity": _infer_metric_polarity(text),
+        "controllability": _infer_metric_controllability(text, lever_candidate),
+        "aliases": aliases,
+        "business_terms": _dedupe_strings([*objective_hits, *lever_hits, *guardrail_hits]),
+        "confidence": confidence,
+        "confidence_reason": "; ".join(evidence) if evidence else "Only generic metric structure was available.",
+        "unresolved_reasons": unresolved_reasons,
+    }
+    return _merge_decision_semantics(inferred, existing)
+
+
+def _build_dimension_decision_semantics(dimension: Dict[str, Any]) -> Dict[str, Any]:
+    existing = dimension.get("decision_semantics") if isinstance(dimension.get("decision_semantics"), dict) else {}
+    text = _semantic_text(dimension, ("id", "dimension_id", "name", "label", "field", "description"))
+    aliases = _semantic_aliases(dimension, ("name", "label", "field"))
+    semantic_kind = str(dimension.get("semantic_kind") or "").strip().lower()
+    data_type = str(dimension.get("data_type") or "").strip().lower()
+    is_temporal = semantic_kind == "temporal" or data_type == "datetime" or bool(_matched_keywords(text, TEMPORAL_KEYWORDS))
+    is_identifier = bool(_matched_keywords(text, IDENTIFIER_KEYWORDS))
+
+    segment_candidate = not is_temporal and not is_identifier
+    comparison_candidate = segment_candidate or is_temporal
+    confidence = 0.84 if is_temporal else (0.72 if segment_candidate else 0.42)
+    evidence = []
+    if is_temporal:
+        evidence.append("temporal semantic kind, data type, or name evidence")
+    if segment_candidate:
+        evidence.append("categorical or configured dimension suitable for segmentation")
+    if is_identifier:
+        evidence.append("identifier-like name reduces segmentation confidence")
+
+    unresolved_reasons = []
+    if confidence < 0.55:
+        unresolved_reasons.append("Dimension appears identifier-like or lacks role evidence.")
+
+    inferred = {
+        "segment_candidate": segment_candidate,
+        "comparison_candidate": comparison_candidate,
+        "temporal_candidate": is_temporal,
+        "grain": _infer_dimension_grain(text) if is_temporal else None,
+        "aliases": aliases,
+        "business_terms": _dedupe_strings(_matched_keywords(text, TEMPORAL_KEYWORDS)),
+        "confidence": round(confidence, 2),
+        "confidence_reason": "; ".join(evidence) if evidence else "Only generic dimension structure was available.",
+        "unresolved_reasons": unresolved_reasons,
+    }
+    return _merge_decision_semantics(inferred, existing)
+
+
+def _semantic_text(item: Dict[str, Any], keys: Sequence[str]) -> str:
+    return " ".join(str(item.get(key) or "").lower() for key in keys)
+
+
+def _semantic_aliases(item: Dict[str, Any], keys: Sequence[str]) -> List[str]:
+    aliases: List[str] = []
+    for key in keys:
+        value = str(item.get(key) or "").strip()
+        if value:
+            aliases.append(value)
+            normalized = " ".join(re.findall(r"[a-z0-9%]+", value.lower()))
+            if normalized and normalized != value.lower():
+                aliases.append(normalized)
+    return _dedupe_strings(aliases)
+
+
+def _matched_keywords(text: str, keywords: Sequence[str]) -> List[str]:
+    normalized = " " + re.sub(r"[^a-z0-9%]+", " ", str(text or "").lower()) + " "
+    return [
+        keyword
+        for keyword in keywords
+        if f" {keyword} " in normalized or keyword in normalized.strip().split()
+    ]
+
+
+def _infer_metric_polarity(text: str) -> str:
+    positive_hits = _matched_keywords(text, POSITIVE_POLARITY_KEYWORDS)
+    negative_hits = _matched_keywords(text, NEGATIVE_POLARITY_KEYWORDS)
+    if positive_hits and not negative_hits:
+        return "increase_is_good"
+    if negative_hits and not positive_hits:
+        return "decrease_is_good"
+    if positive_hits and negative_hits:
+        return "context_dependent"
+    return "unknown"
+
+
+def _infer_metric_controllability(text: str, lever_candidate: bool) -> str:
+    if lever_candidate:
+        return "controllable"
+    if _matched_keywords(text, ("revenue", "profit", "margin", "delivery", "return", "risk", "stockout")):
+        return "outcome"
+    return "unknown"
+
+
+def _infer_dimension_grain(text: str) -> Optional[str]:
+    for grain in GRAIN_KEYWORDS:
+        if grain in text:
+            return grain
+    return "observed_value"
+
+
+def _merge_decision_semantics(inferred: Dict[str, Any], existing: Dict[str, Any]) -> Dict[str, Any]:
+    merged = deepcopy(inferred)
+    for key, value in existing.items():
+        if value is not None:
+            merged[key] = deepcopy(value)
+    merged["aliases"] = _dedupe_strings(list(inferred.get("aliases") or []) + list(existing.get("aliases") or []))
+    merged["business_terms"] = _dedupe_strings(
+        list(inferred.get("business_terms") or []) + list(existing.get("business_terms") or [])
+    )
+    merged["unresolved_reasons"] = _dedupe_strings(
+        list(inferred.get("unresolved_reasons") or []) + list(existing.get("unresolved_reasons") or [])
+    )
+    return merged
+
+
+def _dedupe_strings(items: Sequence[str]) -> List[str]:
+    ordered: List[str] = []
+    for item in items:
+        text = str(item or "").strip()
+        if text and text not in ordered:
+            ordered.append(text)
+    return ordered
 
 
 def _metric_sort_key(metric: Dict[str, Any]) -> tuple:

--- a/frontend/frontend/src/features/ai/AIShell.css
+++ b/frontend/frontend/src/features/ai/AIShell.css
@@ -539,6 +539,47 @@
   color: var(--text-primary);
 }
 
+.ai-shell__preview-actions,
+.ai-shell__artifact-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.ai-shell__export-icon-btn {
+  width: 32px !important;
+  height: 32px !important;
+  color: var(--text-secondary) !important;
+  border: 1px solid var(--border-color) !important;
+  background: var(--bg-primary) !important;
+  transition: all 0.2s ease !important;
+}
+
+.ai-shell__export-icon-btn:hover {
+  color: var(--accent-red) !important;
+  border-color: color-mix(in srgb, var(--accent-red) 35%, var(--border-color)) !important;
+  background: color-mix(in srgb, var(--accent-red) 8%, var(--bg-primary)) !important;
+}
+
+.ai-shell__export-icon-btn.is-preview-export {
+  opacity: 0.75;
+}
+
+.ai-shell__artifact-export-bar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-bottom: 16px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--border-color);
+  color: var(--text-secondary);
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
 /* Full Artifact Containers (Inspector Only) */
 .ai-shell__artifact-preview-card {
   background-color: var(--bg-primary);

--- a/frontend/frontend/src/features/ai/AIShell.jsx
+++ b/frontend/frontend/src/features/ai/AIShell.jsx
@@ -1,13 +1,13 @@
 import React, { useState, useContext, useEffect, useRef, useMemo } from 'react';
 import axios from 'axios';
-import { 
-  FaRobot, FaRegCommentDots, FaTools, FaBook, FaDatabase, FaPlus, FaLightbulb, 
+import {
+  FaRobot, FaRegCommentDots, FaTools, FaBook, FaDatabase, FaPlus, FaLightbulb,
   FaHistory, FaChartBar, FaShieldAlt, FaCircle, FaInfoCircle, FaPaperPlane,
   FaCheckCircle, FaExclamationTriangle, FaExternalLinkAlt, FaLayerGroup, FaFileAlt,
-  FaEye, FaChevronRight, FaTerminal, FaSearch, FaCloud
+  FaEye, FaChevronRight, FaTerminal, FaSearch, FaCloud, FaFilePdf
 } from "react-icons/fa";
-import { 
-  TextField, Button, Box, Typography, Divider, Tooltip, Chip, 
+import {
+  TextField, Button, Box, Typography, Divider, Tooltip, Chip,
   Avatar, Tabs, Tab, Drawer, IconButton
 } from '@mui/material';
 import { DataContext } from '../../context/DataContext';
@@ -16,6 +16,8 @@ import MentionDropdown from '../../components/data_management/MentionDropdown';
 import { detectToken, extractTokens } from '../../utils/mentionUtils';
 import { AICommands } from '../workflow/AiCommandBlock';
 import AICharts from './AICharts';
+import SemanticRef from '../business/decision/SemanticRef';
+import { generateDecisionArtifactPdf } from '../../utils/decisionPdfExport';
 import './AIShell.css';
 
 const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000';
@@ -36,7 +38,7 @@ const MODES = [
 
 /**
  * AIShell (Analytics-Agent Workspace)
- * 
+ *
  * Re-implemented as a high-fidelity workspace with split conversation and inspection.
  */
 function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspace }) {
@@ -56,11 +58,11 @@ function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspa
   const [error, setError] = useState(null);
   const [awaitingCleanInstructions, setAwaitingCleanInstructions] = useState(false);
   const [activeWorkspaceTab, setActiveWorkspaceTab] = useState('threads');
-  
+
   // Phase 4 Logic State
   const [sessionState, setSessionState] = useState({});
-  const [activeMode, setActiveMode] = useState('ask'); 
-  const [activeArtifact, setActiveArtifact] = useState(null); 
+  const [activeMode, setActiveMode] = useState('ask');
+  const [activeArtifact, setActiveArtifact] = useState(null);
   const [isResultsPaneOpen, setIsResultsPaneOpen] = useState(true);
   const [isContextPaneOpen, setIsContextPaneOpen] = useState(false);
 
@@ -139,9 +141,9 @@ function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspa
           return;
         }
 
-        const newAssistantMsg = { 
-          role: "assistant", 
-          content: data.assistant_message, 
+        const newAssistantMsg = {
+          role: "assistant",
+          content: data.assistant_message,
           artifacts: data.artifacts,
           suggested_actions: data.suggested_actions || data.session_state?.available_actions || [],
           mode: data.mode,
@@ -152,7 +154,7 @@ function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspa
         setUserMessages(prev => [...prev, newAssistantMsg]);
         setSessionState(data.session_state || {});
         if (data.mode) setActiveMode(data.mode);
-        
+
         if (data.artifacts && data.artifacts.length > 0) {
           const lastArt = data.artifacts[data.artifacts.length - 1];
           // Only auto-focus if it's a rich, inspectable artifact
@@ -181,8 +183,8 @@ function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspa
   const handleModeChange = (event, newMode) => {
     if (!newMode) return;
     setActiveMode(newMode);
-    setSessionState(prev => ({ 
-      ...prev, 
+    setSessionState(prev => ({
+      ...prev,
       active_mode: newMode,
       mode_context: {
         ...(prev.mode_context || {}),
@@ -259,16 +261,62 @@ function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspa
     setIsResultsPaneOpen(true);
   };
 
+  const isPdfExportableArtifact = (artifact) => {
+    return ['answer', 'chart', 'workspace_preview', 'workspace_analysis_summary'].includes(artifact?.type);
+  };
+
+  const handleExportArtifactPdf = (artifact, messageSessionState = null, messageCapabilityState = null, messageDecisionReadiness = null) => {
+    if (!isPdfExportableArtifact(artifact)) return;
+
+    generateDecisionArtifactPdf({
+      artifact,
+      contextSessionState: messageSessionState || artifact.contextSessionState || sessionState,
+      contextCapabilityState: messageCapabilityState || artifact.contextCapabilityState || sessionState?.capability_state,
+      contextDecisionReadiness: messageDecisionReadiness || artifact.contextDecisionReadiness || sessionState?.decision_readiness,
+    });
+  };
+
+  const renderArtifactExportButton = (artifact, messageSessionState = null, messageCapabilityState = null, messageDecisionReadiness = null, className = '') => {
+    if (!isPdfExportableArtifact(artifact)) return null;
+
+    return (
+      <Tooltip title="Export result as PDF" arrow>
+        <IconButton
+          size="small"
+          className={`ai-shell__export-icon-btn ${className}`}
+          aria-label="Export result as PDF"
+          onClick={(event) => {
+            event.stopPropagation();
+            handleExportArtifactPdf(artifact, messageSessionState, messageCapabilityState, messageDecisionReadiness);
+          }}
+        >
+          <FaFilePdf />
+        </IconButton>
+      </Tooltip>
+    );
+  };
+
+  const renderArtifactExportBar = (artifact, messageSessionState = null, messageCapabilityState = null, messageDecisionReadiness = null) => {
+    if (!isPdfExportableArtifact(artifact)) return null;
+
+    return (
+      <div className="ai-shell__artifact-export-bar">
+        <span>Export this result for review</span>
+        {renderArtifactExportButton(artifact, messageSessionState, messageCapabilityState, messageDecisionReadiness)}
+      </div>
+    );
+  };
+
   const renderArtifact = (artifact, isInspector = false, contextActions = null, contextSessionState = null, contextCapabilityState = null, contextDecisionReadiness = null) => {
     if (!artifact) return null;
 
-    const { 
-      type, 
-      content, 
-      render_hint, 
-      inspectable, 
-      source, 
-      mode: artMode 
+    const {
+      type,
+      content,
+      render_hint,
+      inspectable,
+      source,
+      mode: artMode
     } = artifact;
 
     // Use passed context metadata or stored artifact context for inspector
@@ -278,7 +326,7 @@ function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspa
     const lookupDecisionReadiness = contextDecisionReadiness || artifact.contextDecisionReadiness || sessionState?.decision_readiness;
 
     const baseClass = isInspector ? "ai-shell__active-artifact" : "ai-shell__artifact-preview-card";
-    
+
     // Metadata-driven visibility: In-thread we show links for inspectable rich content
     // unless render_hint explicitly asks for 'inline' presentation.
     if (!isInspector && inspectable && render_hint !== 'inline') {
@@ -299,9 +347,12 @@ function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspa
               {content?.title || content?.chartType || content?.summary?.headline || content?.metric?.label || content?.metric?.name || content?.fieldsUsed?.value || 'View Details'}
             </Typography>
           </div>
-          <IconButton size="small" className="ai-shell__preview-action" aria-label="View Details">
-            <FaChevronRight />
-          </IconButton>
+          <div className="ai-shell__preview-actions">
+            {renderArtifactExportButton(artifact, contextSessionState, contextCapabilityState, contextDecisionReadiness, 'is-preview-export')}
+            <IconButton size="small" className="ai-shell__preview-action" aria-label="View Details">
+              <FaChevronRight />
+            </IconButton>
+          </div>
         </div>
       );
     }
@@ -319,10 +370,16 @@ function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspa
                 <span className="ai-shell__artifact-title">
                    <FaCheckCircle /> {source || 'Result'} {artMode ? `(${artMode})` : ''}
                 </span>
-                {inspectable && <IconButton size="small" onClick={() => handleInspect(artifact, contextActions, contextSessionState, contextCapabilityState, contextDecisionReadiness)} aria-label="Inspect Result"><FaExternalLinkAlt style={{ fontSize: '0.7rem' }} /></IconButton>}
+                <div className="ai-shell__artifact-header-actions">
+                  {renderArtifactExportButton(artifact, contextSessionState, contextCapabilityState, contextDecisionReadiness)}
+                  {inspectable && <IconButton size="small" onClick={() => handleInspect(artifact, contextActions, contextSessionState, contextCapabilityState, contextDecisionReadiness)} aria-label="Inspect Result"><FaExternalLinkAlt style={{ fontSize: '0.7rem' }} /></IconButton>}
+                </div>
               </div>
             )}
-            <div className="ai-shell__artifact-content">{renderAnswerArtifact(content)}</div>
+            <div className="ai-shell__artifact-content">
+              {isInspector && renderArtifactExportBar(artifact, lookupSessionState, lookupCapabilityState, lookupDecisionReadiness)}
+              {renderAnswerArtifact(content)}
+            </div>
           </div>
         );
 
@@ -331,6 +388,7 @@ function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspa
           <div className={`${baseClass} is-chart`}>
             {isInspector && (
               <div className="ai-shell__artifact-content" style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
+                {renderArtifactExportBar(artifact, lookupSessionState, lookupCapabilityState, lookupDecisionReadiness)}
                 <AICharts aiChartType={content?.chartType || 'Bar'} aiChartData={content?.chartData} />
                 {content?.explanation && (
                   <Typography variant="caption" sx={{ mt: 2, display: 'block', opacity: 0.6 }}>{content.explanation}</Typography>
@@ -348,7 +406,7 @@ function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspa
         const artCs = wp.capability_state || wp.content?.capability_state || dr?.capability_state;
         const respCs = lookupCapabilityState;
         const cs = { ...respCs, ...artCs };
-        
+
         // Explicitly merge unsupported_requested_capabilities so they don't get shadowed
         const mergedUnsupported = [
           ...new Set([
@@ -364,15 +422,43 @@ function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspa
         // Backend now sends decision_kickoff as an object
         const isKickoff = !!wp.decision_kickoff;
 
-        // Helper to format object arrays into labels
-        const formatLabels = (items) => {
-          if (!Array.isArray(items)) return 'Not specified';
-          return items.map(item => item.label || item.name || item).join(', ');
+        // Helper to format object arrays into SemanticRef components
+        const renderSemanticList = (items, type) => {
+          if (!Array.isArray(items) || items.length === 0) return <Typography variant="body2" sx={{ opacity: 0.5 }}>Not specified</Typography>;
+          return (
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px', paddingLeft: '12px', borderLeft: '2px solid var(--text-primary)' }}>
+              {items.map((item, i) => {
+                const metricRef = item.metric_ref || (type === 'lever' && item.binding?.binding_type === 'metric' ? item.binding.metric_ref : null);
+                const dimensionRef = item.dimension_ref || (type === 'lever' && item.binding?.binding_type === 'dimension' ? item.binding.dimension_ref : null);
+
+                if (metricRef?.metric_id || dimensionRef?.dimension_id) {
+                  return <SemanticRef key={i} metric_ref={metricRef} dimension_ref={dimensionRef} type={type} compact />;
+                }
+
+                // Build a fallback ref from flattened fields
+                const fallbackLabel = item.label || item.binding_label || item.metric || item.dimension_id || item.field || item.strings || (typeof item === 'string' ? item : 'Unbound item');
+                const fallbackRef = { label: fallbackLabel };
+
+                return (
+                  <SemanticRef
+                    key={i}
+                    metric_ref={type !== 'segment' ? fallbackRef : null}
+                    dimension_ref={type === 'segment' ? fallbackRef : null}
+                    type={type}
+                    compact
+                  />
+                );
+              })}
+            </div>
+          );
         };
+
+        const unresolvedMappings = wp.drafting?.prompt_matches?.unresolved_mappings || wp.unresolved_mappings || [];
 
         return (
           <div className={`${baseClass} is-workspace_preview`}>
             <div className="ai-shell__artifact-content">
+              {isInspector && renderArtifactExportBar(artifact, lookupSessionState, lookupCapabilityState, lookupDecisionReadiness)}
               {isKickoff ? (
                 <div className="ai-shell__kickoff-container">
                   <header className="ai-shell__kickoff-header" style={{ marginBottom: '24px' }}>
@@ -383,7 +469,7 @@ function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspa
                       {wp.title || 'Untitled Decision Framework'}
                     </Typography>
                   </header>
-                  
+
                   <div className="ai-shell__kickoff-summary" style={{ marginBottom: '28px' }}>
                     <Typography variant="body1" sx={{ lineHeight: 1.6, opacity: 0.9, fontSize: '1.05rem' }}>
                       {wp.decision_kickoff?.summary || wp.decision_kickoff}
@@ -393,7 +479,17 @@ function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspa
                   <div className="ai-shell__kickoff-grid" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: '20px', marginBottom: '32px' }}>
                     <div className="ai-shell__kickoff-item">
                       <Typography variant="overline" sx={{ fontWeight: 900, opacity: 0.4, display: 'block', mb: 0.5 }}>Objective</Typography>
-                      <Typography variant="body2" sx={{ fontWeight: 700, borderLeft: '2px solid var(--text-primary)', pl: 1.5 }}>{wp.objective_metric?.label || wp.objective_metric || 'Not specified'}</Typography>
+                      {wp.objective_metric ? (
+                        <div style={{ paddingLeft: '12px', borderLeft: '2px solid var(--text-primary)' }}>
+                          <SemanticRef
+                            metric_ref={wp.objective_metric.metric_id ? wp.objective_metric : { label: typeof wp.objective_metric === 'string' ? wp.objective_metric : wp.objective_metric?.label || wp.objective_metric?.name || 'Not specified' }}
+                            type="objective"
+                            compact
+                          />
+                        </div>
+                      ) : (
+                        <Typography variant="body2" sx={{ fontWeight: 700, borderLeft: '2px solid var(--text-primary)', pl: 1.5, opacity: 0.5 }}>Not specified</Typography>
+                      )}
                     </div>
                     <div className="ai-shell__kickoff-item">
                       <Typography variant="overline" sx={{ fontWeight: 900, opacity: 0.4, display: 'block', mb: 0.5 }}>Time Horizon</Typography>
@@ -401,17 +497,53 @@ function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspa
                     </div>
                     <div className="ai-shell__kickoff-item">
                       <Typography variant="overline" sx={{ fontWeight: 900, opacity: 0.4, display: 'block', mb: 0.5 }}>Primary Levers</Typography>
-                      <Typography variant="body2" sx={{ fontWeight: 700, borderLeft: '2px solid var(--text-primary)', pl: 1.5 }}>{formatLabels(wp.levers)}</Typography>
+                      {renderSemanticList(wp.levers, 'lever')}
                     </div>
                     <div className="ai-shell__kickoff-item">
                       <Typography variant="overline" sx={{ fontWeight: 900, opacity: 0.4, display: 'block', mb: 0.5 }}>Segmentation</Typography>
-                      <Typography variant="body2" sx={{ fontWeight: 700, borderLeft: '2px solid var(--text-primary)', pl: 1.5 }}>{formatLabels(wp.segment_dimensions)}</Typography>
+                      {renderSemanticList(wp.segment_dimensions, 'segment')}
                     </div>
                     <div className="ai-shell__kickoff-item" style={{ gridColumn: '1 / -1' }}>
                       <Typography variant="overline" sx={{ fontWeight: 900, opacity: 0.4, display: 'block', mb: 0.5 }}>Guardrails</Typography>
-                      <Typography variant="body2" sx={{ fontWeight: 700, borderLeft: '2px solid var(--text-primary)', pl: 1.5 }}>{formatLabels(wp.guardrails)}</Typography>
+                      {renderSemanticList(wp.guardrails, 'guardrail')}
                     </div>
                   </div>
+
+                  {unresolvedMappings.length > 0 && (
+                    <div className="ai-shell__unresolved-zone" style={{ marginBottom: '32px', padding: '16px', borderRadius: '12px', background: 'rgba(239, 68, 68, 0.05)', border: '1px solid rgba(239, 68, 68, 0.1)' }}>
+                      <Typography variant="overline" sx={{ fontWeight: 900, color: '#ef4444', display: 'block', mb: 1.5 }}>Unresolved Semantic Mappings</Typography>
+                      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
+                        {unresolvedMappings.map((m, i) => {
+                          const mappingType = m.mapping_type || 'unresolved';
+                          const coreTerm = m.label || m.name || m.term || m.field || 'unknown term';
+                          const candidateSummary = m.candidate_labels?.length > 0 ? ` [${m.candidate_labels[0]}${m.candidate_labels.length > 1 ? '...' : ''}]` : '';
+                          const reasonInfo = m.reason ? ` (${m.reason})` : '';
+
+                          // Build high-fidelity label from type + term + metadata
+                          const labelText = `${mappingType}: ${coreTerm}${candidateSummary}${reasonInfo}`;
+
+                          const ref = {
+                            label: labelText,
+                            confidence: m.confidence,
+                            reason: m.reason,
+                            candidate_labels: m.candidate_labels
+                          };
+                          return (
+                            <SemanticRef
+                              key={i}
+                              metric_ref={m.mapping_type === 'metric' ? ref : null}
+                              dimension_ref={m.mapping_type === 'dimension' ? ref : null}
+                              type="unresolved"
+                              compact
+                            />
+                          );
+                        })}
+                      </div>
+                      <Typography variant="caption" sx={{ display: 'block', mt: 1.5, opacity: 0.6 }}>
+                        These terms were identified in your prompt but could not be confidently bound to the current semantic model.
+                      </Typography>
+                    </div>
+                  )}
 
                   <Divider sx={{ mb: 3, opacity: 0.1 }} />
 
@@ -463,7 +595,7 @@ function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspa
                       const actionId = wp.recommended_next_action?.action_id || wp.recommended_next_action;
                       // Use the scoped lookupActions from renderArtifact scope
                       const fullAction = lookupActions.find(a => a.action_id === actionId) || wp.recommended_next_action;
-                      
+
                       const isPrimary = fullAction?.priority === 'primary';
                       const isEnabled = dr?.allowed_next_actions ? dr.allowed_next_actions.includes(actionId) : fullAction?.enabled !== false;
                       const blockerInfo = dr?.blocked_state?.is_blocked ? dr.blocked_state.blocking_missing_inputs?.join(', ') : null;
@@ -474,22 +606,22 @@ function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspa
                           <Typography variant="overline" sx={{ fontWeight: 900, opacity: 0.5, display: 'block', mb: 1.5 }}>Recommended Next Step</Typography>
                           <Tooltip title={tooltip} arrow>
                             <span>
-                              <Button 
-                                variant="contained" 
+                              <Button
+                                variant="contained"
                                 fullWidth
                                 disabled={loading || !isEnabled}
                                 startIcon={<FaSearch />}
-                                sx={{ 
-                                  borderRadius: '12px', 
+                                sx={{
+                                  borderRadius: '12px',
                                   py: 1.5,
-                                  textTransform: 'none', 
-                                  fontWeight: 900, 
+                                  textTransform: 'none',
+                                  fontWeight: 900,
                                   fontSize: '0.9rem',
                                   bgcolor: isPrimary ? 'var(--text-primary)' : 'var(--bg-secondary)',
                                   color: isPrimary ? 'var(--bg-primary)' : 'var(--text-primary)',
-                                  '&:hover': { 
-                                    bgcolor: isPrimary ? 'var(--text-primary)' : 'var(--bg-tertiary)', 
-                                    filter: 'brightness(1.1)' 
+                                  '&:hover': {
+                                    bgcolor: isPrimary ? 'var(--text-primary)' : 'var(--bg-tertiary)',
+                                    filter: 'brightness(1.1)'
                                   },
                                   '&:disabled': {
                                     opacity: 0.5,
@@ -520,7 +652,7 @@ function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspa
                   </div>
                 </>
               )}
-              
+
               {wp.missing_inputs?.length > 0 && (
                 <div className="ai-shell__kickoff-clarifications" style={{ marginTop: '32px' }}>
                   <Typography variant="overline" sx={{ fontWeight: 900, opacity: 0.5, display: 'block', mb: 2 }}>Required Clarifications</Typography>
@@ -543,6 +675,7 @@ function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspa
         return (
           <div className={`${baseClass} is-workspace_analysis_summary`}>
             <div className="ai-shell__artifact-content">
+              {isInspector && renderArtifactExportBar(artifact, lookupSessionState, lookupCapabilityState, lookupDecisionReadiness)}
               {hasItems ? (
                 <div className="ai-shell__analysis-list">
                   <Typography variant="overline" sx={{ fontWeight: 900, mb: 2, display: 'block', opacity: 0.5 }}>Diagnostic Breakdown {artMode ? `• ${artMode.toUpperCase()}` : ''}</Typography>
@@ -550,10 +683,10 @@ function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspa
                     const isObj = typeof item === 'object' && item !== null;
                     // Primary text: Prefer label, then statement, then headline, then title
                     const statement = isObj ? (item.label || item.statement || item.headline || item.title) : item;
-                    
+
                     // Secondary text: Prefer description, then summary, then reason, then category
                     const description = isObj ? (item.description || item.summary || item.reason || (item.category ? `Category: ${item.category}` : null)) : null;
-                    
+
                     // Severity/Blocker logic: check blocks_simulation, is_blocker, or high/critical severity
                     const isBlocker = isObj ? !!(item.blocks_simulation || item.is_blocker || item.severity === 'high' || item.severity === 'critical') : false;
 
@@ -654,7 +787,7 @@ function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspa
 
     const dsContext = resolveDatasetForNlp();
     const msg = userInput;
-    setUserInput(''); 
+    setUserInput('');
 
     setUserMessages(prev => [...prev, { role: "user", content: msg, grounded: resolvedDatasets.length > 0 }]);
 
@@ -725,9 +858,9 @@ function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspa
       const data = response.data;
 
       if (data.status === 'success') {
-        const newMsg = { 
-          role: "assistant", 
-          content: data.assistant_message, 
+        const newMsg = {
+          role: "assistant",
+          content: data.assistant_message,
           artifacts: data.artifacts,
           suggested_actions: data.suggested_actions || [],
           mode: data.mode,
@@ -738,7 +871,7 @@ function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspa
         setUserMessages(prev => [...prev, newMsg]);
         setSessionState(data.session_state || {});
         if (data.mode) setActiveMode(data.mode);
-        
+
         if (data.artifacts && data.artifacts.length > 0) {
           const lastArt = data.artifacts[data.artifacts.length - 1];
           // Only auto-focus if it's a rich, inspectable artifact
@@ -781,8 +914,8 @@ function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspa
         <div className="ai-shell__rail-top">
           {MODES.map(m => (
             <Tooltip key={m.id} title={m.label} placement="right">
-              <button 
-                className={`ai-shell__rail-item ${activeMode === m.id ? 'is-active' : ''}`} 
+              <button
+                className={`ai-shell__rail-item ${activeMode === m.id ? 'is-active' : ''}`}
                 onClick={() => handleModeChange(null, m.id)}
                 aria-label={m.label}
               >
@@ -804,8 +937,8 @@ function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspa
             </button>
           </Tooltip>
           <Tooltip title="Context & Metadata" placement="right">
-            <button 
-              className={`ai-shell__rail-item ${isContextPaneOpen ? 'is-active' : ''}`} 
+            <button
+              className={`ai-shell__rail-item ${isContextPaneOpen ? 'is-active' : ''}`}
               onClick={() => setIsContextPaneOpen(true)}
               aria-label="Context & Metadata"
             >
@@ -821,9 +954,9 @@ function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspa
         open={isContextPaneOpen}
         onClose={() => setIsContextPaneOpen(false)}
         PaperProps={{
-          sx: { 
-            width: 350, 
-            bgcolor: 'var(--bg-primary)', 
+          sx: {
+            width: 350,
+            bgcolor: 'var(--bg-primary)',
             borderRight: '1px solid var(--border-color)',
             boxShadow: '20px 0 50px rgba(0,0,0,0.3)',
             color: 'var(--text-primary)',
@@ -858,7 +991,7 @@ function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspa
           </div>
 
           <Divider sx={{ my: 2, borderColor: 'var(--border-color)' }} />
-          
+
           <div className="ai-shell__context-module">
             <div className="ai-shell__module-header"><span className="ai-shell__module-title">Schema Metadata</span><span className="ai-shell__coming-soon">Soon</span></div>
             <div className="ai-shell__module-empty">No metadata overrides detected.</div>
@@ -920,8 +1053,8 @@ function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspa
           <div className="ai-shell__mode-container">
             <div className="ai-shell__mode-group">
               {MODES.map(m => (
-                <button 
-                  key={m.id} 
+                <button
+                  key={m.id}
                   className={`ai-shell__mode-btn ${activeMode === m.id ? 'is-active' : ''}`}
                   onClick={() => handleModeChange(null, m.id)}
                 >
@@ -956,7 +1089,7 @@ function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspa
               </div>
             </div>
           )}
-          
+
           {userMessages.map((msg, idx) => (
             <div key={idx} className={`ai-shell__message-row is-${msg.role}`}>
               <div className="ai-shell__message-card">
@@ -965,7 +1098,7 @@ function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspa
                   {(msg.grounded || msg.role === 'assistant') && <span className="ai-shell__grounded-tag"><FaShieldAlt /> Grounded</span>}
                 </div>
                 <div className="ai-shell__message-content">{msg.content}</div>
-                
+
                 {msg.artifacts && msg.artifacts.length > 0 && (
                   <div className="ai-shell__artifact-container">
                     {msg.artifacts.map((art, aIdx) => <React.Fragment key={aIdx}>{renderArtifact(art, false, msg.suggested_actions, msg.session_state, msg.capability_state, msg.decision_readiness)}</React.Fragment>)}
@@ -989,8 +1122,8 @@ function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspa
                       .map((act, actIdx) => (
                         <Tooltip key={actIdx} title={act.availability_reason || act.description || ''} arrow>
                           <span>
-                            <button 
-                              className={`ai-shell__action-btn ${act.priority === 'primary' ? 'is-primary' : ''} ${!act.enabled ? 'is-disabled' : ''}`} 
+                            <button
+                              className={`ai-shell__action-btn ${act.priority === 'primary' ? 'is-primary' : ''} ${!act.enabled ? 'is-disabled' : ''}`}
                               onClick={() => handleActionClick(act.action_id, msg.session_state)}
                               disabled={loading || !act.enabled}
                             >

--- a/frontend/frontend/src/features/business/decision/DecisionWorkspace.css
+++ b/frontend/frontend/src/features/business/decision/DecisionWorkspace.css
@@ -150,6 +150,49 @@
   border-color: var(--text-secondary);
 }
 
+.header-top,
+.header-actions,
+.status-group {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.header-top {
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.header-actions {
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.decision-export-btn {
+  padding: 8px 14px;
+  border-radius: 6px;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  font-size: 0.8rem;
+  font-weight: 700;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  transition: all 0.2s ease;
+}
+
+.decision-export-btn svg {
+  color: var(--accent-red);
+  font-size: 0.9rem;
+}
+
+.decision-export-btn:hover {
+  background: color-mix(in srgb, var(--accent-red) 7%, var(--bg-secondary));
+  border-color: color-mix(in srgb, var(--accent-red) 35%, var(--border-color));
+}
+
 .remove-btn {
   padding: 8px;
   border-radius: 6px;
@@ -447,6 +490,90 @@
   background: var(--bg-secondary);
   color: var(--text-secondary);
   border-style: dashed;
+}
+
+/* Semantic Reference Components */
+.semantic-ref {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 12px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  cursor: help;
+  transition: all 0.2s ease;
+}
+
+.semantic-ref:hover {
+  border-color: var(--text-secondary);
+  background: var(--bg-secondary);
+}
+
+.semantic-ref.is-compact {
+  padding: 4px 8px;
+  font-size: 0.8rem;
+  gap: 8px;
+}
+
+.semantic-ref.is-unresolved {
+  background: rgba(239, 68, 68, 0.05);
+  border-color: rgba(239, 68, 68, 0.2);
+  color: #ef4444;
+}
+
+.ref-main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ref-icon {
+  font-size: 0.8rem;
+  opacity: 0.6;
+}
+
+.ref-confidence {
+  font-size: 0.7rem;
+  font-weight: 800;
+  opacity: 0.9;
+  background: rgba(0,0,0,0.05);
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.ref-badges {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding-left: 8px;
+  border-left: 1px solid var(--border-color);
+}
+
+.role-badge {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  font-size: 0.65rem;
+  opacity: 0.5;
+}
+
+.ref-warning-icon {
+  color: #f59e0b;
+  font-size: 0.8rem;
+}
+
+.ref-warning-dot {
+  width: 6px;
+  height: 6px;
+  background: #ef4444;
+  border-radius: 50%;
+  margin-left: 4px;
 }
 
 /* Responsiveness */

--- a/frontend/frontend/src/features/business/decision/DecisionWorkspaceView.jsx
+++ b/frontend/frontend/src/features/business/decision/DecisionWorkspaceView.jsx
@@ -1,24 +1,25 @@
 import React from 'react';
 import Typography from '@mui/material/Typography';
-import { 
-  FaCircleCheck, FaCircleExclamation, FaTriangleExclamation, FaCircleInfo, 
-  FaGears, FaShieldHalved, FaChartLine, FaLayerGroup, FaPlus, FaCalendarDays, FaFileLines, FaLink, FaClock,
-  FaMagnifyingGlassChart, FaFlask, FaScaleBalanced, FaLightbulb, FaBrain
+import {
+  FaCircleCheck, FaCircleExclamation, FaTriangleExclamation, FaCircleInfo,
+  FaGears, FaShieldHalved, FaChartLine, FaLayerGroup, FaPlus, FaCalendarDays, FaFileLines, FaClock,
+  FaMagnifyingGlassChart, FaFlask, FaScaleBalanced, FaLightbulb, FaBrain, FaFilePdf
 } from 'react-icons/fa6';
 import './DecisionWorkspace.css';
 import DecisionSignals from './DecisionSignals';
 import DecisionRecommendations from './DecisionRecommendations';
+import SemanticRef from './SemanticRef';
+import { generateDecisionWorkspacePdf } from '../../../utils/decisionPdfExport';
 
 /**
  * ScopedDiagnosticCard
- * 
+ *
  * Renders a single structured diagnostic item from the workspace analysis.
  * Follows the DI 2.0 V3 contract for truthful, scoped observational diagnostics.
  */
 const ScopedDiagnosticCard = ({ diagnostic }) => {
   const { summary, metric_ref, status, evidence } = diagnostic;
-  const label = metric_ref?.label || 'Workspace Observation';
-  
+
   const getStatusConfig = () => {
     switch (status) {
       case 'observed_change':
@@ -55,7 +56,7 @@ const ScopedDiagnosticCard = ({ diagnostic }) => {
 
     const { delta_pct, current_value, previous_value, delta_value } = evidence;
     const isPositive = (delta_value || 0) > 0;
-    
+
     return (
       <div className="diagnostic-evidence">
         <div className="evidence-grid" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(100px, 1fr))', gap: '12px' }}>
@@ -84,7 +85,9 @@ const ScopedDiagnosticCard = ({ diagnostic }) => {
     <div className={`scoped-diagnostic-card status--${status === 'observed_change' ? 'info' : status === 'insufficient_history' ? 'warning' : 'critical'}`}>
       <div className="diagnostic-header">
         <div className="diagnostic-status-icon">{config.icon}</div>
-        <div className="diagnostic-metric-label">{label}</div>
+        <div className="diagnostic-metric-label">
+          {metric_ref ? <SemanticRef metric_ref={metric_ref} type="diagnostic" compact /> : 'Workspace Observation'}
+        </div>
         <div className={`diagnostic-status-badge ${config.badgeClass}`}>{config.label}</div>
       </div>
       <div className="diagnostic-summary">{summary}</div>
@@ -95,7 +98,7 @@ const ScopedDiagnosticCard = ({ diagnostic }) => {
 
 /**
  * DecisionWorkspaceView
- * 
+ *
  * High-fidelity "Decision Brief" rendering for DI 2.0 V1/V3.
  * Emphasizes the strategic framing over raw data schema.
  */
@@ -120,6 +123,10 @@ const DecisionWorkspaceView = ({ workspace, analysis, onCreateNew, onAnalyze, se
   const dr = decision_readiness || readiness?.decision_readiness || readiness;
   const cs = dr?.capability_state || readiness?.capability_state;
 
+  const handleExportWorkspacePdf = () => {
+    generateDecisionWorkspacePdf({ workspace, analysis });
+  };
+
   const renderStatusBadge = () => {
     const currentState = dr?.readiness_state || status;
     switch (currentState) {
@@ -140,8 +147,8 @@ const DecisionWorkspaceView = ({ workspace, analysis, onCreateNew, onAnalyze, se
 
   const formatDate = (dateStr) => {
     try {
-      return new Date(dateStr).toLocaleString('en-US', { 
-        month: 'short', day: 'numeric', year: 'numeric', hour: '2-digit', minute: '2-digit' 
+      return new Date(dateStr).toLocaleString('en-US', {
+        month: 'short', day: 'numeric', year: 'numeric', hour: '2-digit', minute: '2-digit'
       });
     } catch (e) {
       return dateStr;
@@ -157,6 +164,14 @@ const DecisionWorkspaceView = ({ workspace, analysis, onCreateNew, onAnalyze, se
             <span className="workspace-id">ID: {workspace_id.slice(-8)}</span>
           </div>
           <div className="header-actions">
+            <button
+              className="decision-export-btn"
+              onClick={handleExportWorkspacePdf}
+              aria-label="Export decision workspace as PDF"
+              title="Export decision workspace as PDF"
+            >
+              <FaFilePdf /> Export PDF
+            </button>
             <button className="add-btn" onClick={onCreateNew}>
               <FaPlus /> New Decision
             </button>
@@ -227,11 +242,11 @@ const DecisionWorkspaceView = ({ workspace, analysis, onCreateNew, onAnalyze, se
               )}
               {decision_scope.objective.metric_ref ? (
                 <div className="binding-resolved" style={{ marginTop: '20px' }}>
-                  <FaLink /> Anchor Metric: <strong>{decision_scope.objective.metric_ref.label}</strong>
+                  <SemanticRef metric_ref={decision_scope.objective.metric_ref} type="objective" />
                 </div>
               ) : (
                 <div className="binding-unresolved" style={{ marginTop: '20px' }}>
-                  <FaCircleExclamation /> Unresolved Metric: {decision_scope.objective.reason || "Manual ID entry required"}
+                  <SemanticRef type="unresolved" metric_ref={{ label: decision_scope.objective.reason || "Manual ID entry required" }} />
                 </div>
               )}
             </div>
@@ -247,7 +262,7 @@ const DecisionWorkspaceView = ({ workspace, analysis, onCreateNew, onAnalyze, se
                     <span className="lever-type">{lever.lever_type}</span>
                   </div>
                   {lever.description && <p className="item-description">{lever.description}</p>}
-                  
+
                   <div className="lever-meta">
                     {lever.desired_change && (
                       <span className="intent-tag">Intent: {lever.desired_change}</span>
@@ -264,11 +279,18 @@ const DecisionWorkspaceView = ({ workspace, analysis, onCreateNew, onAnalyze, se
 
                   {lever.binding && lever.binding.status !== 'unresolved' ? (
                     <div className="binding-resolved">
-                      <FaLink /> Bound to {lever.binding.binding_type}: <strong>{lever.binding.metric_ref?.label || lever.binding.dimension_ref?.label || lever.binding.field}</strong>
+                      <SemanticRef
+                        metric_ref={lever.binding.metric_ref}
+                        dimension_ref={lever.binding.dimension_ref}
+                        type="lever"
+                      />
                     </div>
                   ) : (
                     <div className="binding-unresolved">
-                      <FaCircleExclamation /> Unresolved Lever Binding
+                      <SemanticRef
+                        type="unresolved"
+                        metric_ref={{ label: lever.binding?.binding_label || lever.label || "Unresolved Lever Binding" }}
+                      />
                     </div>
                   )}
                 </div>
@@ -294,7 +316,7 @@ const DecisionWorkspaceView = ({ workspace, analysis, onCreateNew, onAnalyze, se
                       <strong>Constraint Rationale:</strong> {constraint.rationale}
                     </div>
                   )}
-                  
+
                   <div className="constraint-rule">
                     Condition: {constraint.condition.operator} {constraint.condition.value}
                     {constraint.condition.secondary_value && ` and ${constraint.condition.secondary_value}`}
@@ -304,11 +326,18 @@ const DecisionWorkspaceView = ({ workspace, analysis, onCreateNew, onAnalyze, se
 
                   {constraint.binding && constraint.binding.status !== 'unresolved' ? (
                     <div className="binding-resolved">
-                      <FaLink /> Bound to {constraint.binding.binding_type}: <strong>{constraint.binding.metric_ref?.label || constraint.binding.dimension_ref?.label || constraint.binding.field}</strong>
+                      <SemanticRef
+                        metric_ref={constraint.binding.metric_ref}
+                        dimension_ref={constraint.binding.dimension_ref}
+                        type="guardrail"
+                      />
                     </div>
                   ) : (
                     <div className="binding-unresolved">
-                      <FaCircleExclamation /> Unresolved Guardrail Binding
+                      <SemanticRef
+                        type="unresolved"
+                        metric_ref={{ label: constraint.binding?.binding_label || constraint.label || "Unresolved Guardrail Binding" }}
+                      />
                     </div>
                   )}
                 </div>
@@ -325,24 +354,24 @@ const DecisionWorkspaceView = ({ workspace, analysis, onCreateNew, onAnalyze, se
             <div className="context-card">
               <div className="context-group">
                 <label>Relevant Metrics</label>
-                <div className="tag-cloud">
+                <div className="tag-cloud" style={{ gap: '12px' }}>
                   {scoped_context.relevant_metrics.map(m => (
-                    <span key={m.metric_id} className="context-tag">{m.label}</span>
+                    <SemanticRef key={m.metric_id} metric_ref={m} type="relevant" compact />
                   ))}
                 </div>
               </div>
               <div className="context-group">
                 <label>Dimensions & Segments</label>
-                <div className="tag-cloud">
+                <div className="tag-cloud" style={{ gap: '12px' }}>
                   {scoped_context.relevant_dimensions.map(d => (
-                    <span key={d.dimension_id} className="context-tag">{d.label}</span>
+                    <SemanticRef key={d.dimension_id} dimension_ref={d} type="relevant" compact />
                   ))}
                   {scoped_context.comparison_dimensions?.map(d => (
-                    <span key={`comp-${d.dimension_id}`} className="context-tag context-tag--comparison">{d.label}</span>
+                    <SemanticRef key={`comp-${d.dimension_id}`} dimension_ref={d} type="comparison" compact />
                   ))}
                 </div>
               </div>
-              
+
               {scoped_context.applied_filters?.length > 0 && (
                 <div className="context-group">
                   <label>Active Slice Filters</label>
@@ -362,7 +391,7 @@ const DecisionWorkspaceView = ({ workspace, analysis, onCreateNew, onAnalyze, se
                   <div className="temporal-info">
                     {scoped_context.period_context && (
                       <div className="period-label">
-                        {scoped_context.period_context.label} 
+                        {scoped_context.period_context.label}
                         <span style={{ opacity: 0.5, fontWeight: 500, margin: '0 8px' }}>vs</span>
                         {scoped_context.period_context.comparison_label}
                       </div>
@@ -375,7 +404,7 @@ const DecisionWorkspaceView = ({ workspace, analysis, onCreateNew, onAnalyze, se
                   </div>
                 </div>
               )}
-              
+
               {scoped_context.notes && scoped_context.notes.length > 0 && (
                 <div className="context-group">
                   <label>Scoping Intelligence</label>
@@ -460,7 +489,7 @@ const DecisionWorkspaceView = ({ workspace, analysis, onCreateNew, onAnalyze, se
               <span className={`indicator ${readiness.constraint_ready ? 'is-ready' : 'not-ready'}`}>Guardrails</span>
             </div>
           </div>
-          
+
           {(dr?.blocked_state?.is_blocked || readiness.missing_inputs?.length > 0) && (
             <div className="missing-inputs" style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
               <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
@@ -476,7 +505,7 @@ const DecisionWorkspaceView = ({ workspace, analysis, onCreateNew, onAnalyze, se
               </div>
             </div>
           )}
-          
+
           <div className="capability-matrix" style={{ marginTop: '24px', display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: '12px' }}>
             <div className={`capability-tag ${cs?.observational_analysis?.available ? 'is-allowed' : 'is-blocked'}`}>
               <FaMagnifyingGlassChart /> Observational Analysis: {cs?.observational_analysis?.status || (dr?.structural_readiness?.ready_for_observational_analysis ? 'allowed' : 'blocked')}
@@ -491,7 +520,7 @@ const DecisionWorkspaceView = ({ workspace, analysis, onCreateNew, onAnalyze, se
               <FaBrain /> Autonomous: {cs?.autonomous_decisioning?.status || 'unsupported'}
             </div>
           </div>
-          
+
           {dr?.truth_boundary === 'observational_analysis_only' && (
             <div className="analysis-notice" style={{ marginTop: '16px' }}>
               <FaTriangleExclamation /> This decision frame is limited to <strong>observational analysis</strong>. Causal simulation and recommendation engines are currently unsupported.
@@ -551,7 +580,7 @@ const DecisionWorkspaceView = ({ workspace, analysis, onCreateNew, onAnalyze, se
               <h4 className="section-label" style={{ display: 'flex', alignItems: 'center', gap: '8px', color: 'var(--accent-blue)' }}>
                 <FaFlask /> Scoped Diagnostics
               </h4>
-              
+
               <div className="scoped-diagnostics-list">
                 {Array.isArray(analysis.scoped_diagnostics) ? (
                   analysis.scoped_diagnostics.map((diag, idx) => (
@@ -592,7 +621,7 @@ const DecisionWorkspaceView = ({ workspace, analysis, onCreateNew, onAnalyze, se
               </section>
             )}
           </div>
-          
+
           <div className="analysis-footer" style={{ marginTop: '32px', textAlign: 'right', fontSize: '0.75rem', opacity: 0.5 }}>
             Analysis ID: {analysis.analysis_id} • Generated at: {formatDate(analysis.generated_at)}
           </div>

--- a/frontend/frontend/src/features/business/decision/SemanticRef.jsx
+++ b/frontend/frontend/src/features/business/decision/SemanticRef.jsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import { Tooltip, Box, Typography, Chip } from '@mui/material';
+import { 
+  FaLink, FaCircleExclamation, FaTriangleExclamation,
+  FaBullseye, FaGears, FaShieldHalved, FaLayerGroup, FaClock
+} from 'react-icons/fa6';
+
+/**
+ * SemanticRef
+ * 
+ * A compact, high-fidelity renderer for Metric and Dimension references.
+ * Supports Phase 2 semantic role strengthening fields: decision_semantics, 
+ * binding confidence, reasons, sources, and warnings.
+ */
+const SemanticRef = ({ metric_ref, dimension_ref, type, compact = false }) => {
+  const ref = metric_ref || dimension_ref;
+  if (!ref) return null;
+
+  const semantics = ref.decision_semantics;
+  const confidence = ref.semantic_binding_confidence ?? ref.confidence ?? semantics?.confidence;
+  const reason = ref.semantic_binding_reason || ref.reason || semantics?.confidence_reason;
+  const warnings = [...(ref.semantic_role_warnings || []), ...(semantics?.unresolved_reasons || [])];
+  const source = ref.semantic_role_source;
+  const candidateLabels = ref.candidate_labels || [];
+
+  const isUnresolved = type === 'unresolved' || source === 'unresolved' || (!ref.metric_id && !ref.dimension_id);
+
+  // Confidence color mapping
+  const getConfidenceColor = (c) => {
+    if (c === undefined || c === null) return 'var(--text-secondary)';
+    if (c >= 0.8) return 'var(--accent-green)';
+    if (c >= 0.5) return '#f59e0b'; // Amber
+    return '#ef4444'; // Red
+  };
+
+  const roleBadges = [];
+  if (semantics) {
+    if (semantics.objective_candidate) roleBadges.push({ label: 'OBJ', icon: <FaBullseye />, color: 'var(--text-primary)' });
+    if (semantics.lever_candidate) roleBadges.push({ label: 'LVR', icon: <FaGears />, color: 'var(--text-primary)' });
+    if (semantics.guardrail_candidate) roleBadges.push({ label: 'GRD', icon: <FaShieldHalved />, color: 'var(--text-primary)' });
+    if (semantics.segment_candidate) roleBadges.push({ label: 'SEG', icon: <FaLayerGroup />, color: 'var(--text-primary)' });
+    if (semantics.temporal_candidate) roleBadges.push({ label: 'TMP', icon: <FaClock />, color: 'var(--text-primary)' });
+  }
+
+  const renderTooltipContent = () => (
+    <Box sx={{ p: 1, maxWidth: 300 }}>
+      <Typography variant="subtitle2" sx={{ fontWeight: 800, mb: 0.5 }}>
+        {ref.label || ref.name || 'Semantic Reference'}
+      </Typography>
+      
+      {confidence !== undefined && (
+        <Typography variant="caption" sx={{ display: 'block', mb: 1 }}>
+          <strong>Confidence:</strong> {(confidence * 100).toFixed(0)}%
+          <span style={{ 
+            display: 'inline-block', 
+            width: 8, 
+            height: 8, 
+            borderRadius: '50%', 
+            marginLeft: 8, 
+            backgroundColor: getConfidenceColor(confidence) 
+          }} />
+        </Typography>
+      )}
+
+      {reason && (
+        <Typography variant="caption" sx={{ display: 'block', mb: 1, opacity: 0.9 }}>
+          <strong>Evidence:</strong> {reason}
+        </Typography>
+      )}
+
+      {source && (
+        <Typography variant="caption" sx={{ display: 'block', mb: 1, opacity: 0.7, fontStyle: 'italic' }}>
+          Source: {source.replace('_', ' ')}
+        </Typography>
+      )}
+
+      {candidateLabels.length > 0 && (
+        <Box sx={{ mb: 1 }}>
+          <Typography variant="caption" sx={{ display: 'block', fontWeight: 700, opacity: 0.6, fontSize: '0.65rem', textTransform: 'uppercase' }}>
+            Candidates:
+          </Typography>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+            {candidateLabels.map((l, i) => (
+              <Chip key={i} label={l} size="small" sx={{ height: 16, fontSize: '0.6rem', opacity: 0.8 }} />
+            ))}
+          </Box>
+        </Box>
+      )}
+
+      {warnings.length > 0 && (
+        <Box sx={{ mt: 1, pt: 1, borderTop: '1px solid rgba(255,255,255,0.1)' }}>
+          {warnings.map((w, i) => (
+            <Typography key={i} variant="caption" sx={{ display: 'flex', alignItems: 'center', gap: 1, color: '#fca5a5', mb: 0.5 }}>
+              <FaTriangleExclamation fontSize="0.7rem" /> {w}
+            </Typography>
+          ))}
+        </Box>
+      )}
+
+      {semantics?.business_terms?.length > 0 && (
+        <Box sx={{ mt: 1, display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+          {semantics.business_terms.map((term, i) => (
+            <Chip key={i} label={term} size="small" sx={{ height: 16, fontSize: '0.6rem', opacity: 0.6 }} />
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+
+  if (isUnresolved) {
+    return (
+      <Tooltip title={renderTooltipContent()} arrow>
+        <div className="semantic-ref is-unresolved">
+          <FaCircleExclamation className="ref-icon" />
+          <span className="ref-label">{ref.label || ref.name || 'Unresolved mapping'}</span>
+          {warnings.length > 0 && <span className="ref-warning-dot" />}
+        </div>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Tooltip title={renderTooltipContent()} arrow>
+      <div className={`semantic-ref ${compact ? 'is-compact' : ''} type--${type}`}>
+        <div className="ref-main">
+          <FaLink className="ref-icon" />
+          <span className="ref-label">{ref.label}</span>
+          
+          {confidence !== undefined && (
+            <div className="ref-confidence" style={{ color: getConfidenceColor(confidence) }}>
+              {(confidence * 100).toFixed(0)}%
+            </div>
+          )}
+        </div>
+
+        {roleBadges.length > 0 && !compact && (
+          <div className="ref-badges">
+            {roleBadges.map((badge, i) => (
+              <span key={i} className="role-badge" title={badge.label}>
+                {badge.icon}
+              </span>
+            ))}
+          </div>
+        )}
+        
+        {warnings.length > 0 && <FaTriangleExclamation className="ref-warning-icon" />}
+      </div>
+    </Tooltip>
+  );
+};
+
+export default SemanticRef;

--- a/frontend/frontend/src/utils/decisionPdfExport.js
+++ b/frontend/frontend/src/utils/decisionPdfExport.js
@@ -1,0 +1,432 @@
+import { jsPDF } from 'jspdf';
+
+const PAGE = {
+  width: 612,
+  height: 792,
+  marginX: 46,
+  marginY: 48,
+  lineHeight: 14,
+};
+
+const CONTENT_WIDTH = PAGE.width - PAGE.marginX * 2;
+const MAX_APPENDIX_CHARS = 12000;
+
+const sanitizeText = (value) => {
+  if (value === null || value === undefined) return '';
+  const raw = typeof value === 'string' ? value : JSON.stringify(value, null, 2);
+  return Array.from(raw.replace(/[‘’]/g, "'").replace(/[“”]/g, '"'))
+    .filter((char) => {
+      const code = char.charCodeAt(0);
+      return code === 10 || code === 13 || (code >= 32 && code <= 126);
+    })
+    .join('')
+    .replace(/[ \t]+/g, ' ')
+    .trim();
+};
+
+const formatTimestamp = (value) => {
+  const date = value ? new Date(value) : new Date();
+  if (Number.isNaN(date.getTime())) return sanitizeText(value);
+  return date.toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};
+
+const fileDate = () => new Date().toISOString().slice(0, 10);
+
+const readableKey = (key) => sanitizeText(key)
+  .replace(/_/g, ' ')
+  .replace(/\b\w/g, (char) => char.toUpperCase());
+
+const labelForRef = (ref) => {
+  if (!ref) return '';
+  return sanitizeText(ref.label || ref.name || ref.metric_id || ref.dimension_id || ref.field || ref.binding_label);
+};
+
+const labelForValue = (value) => {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return sanitizeText(String(value));
+  }
+  return sanitizeText(value.label || value.name || value.metric || value.field || value.dimension_id || value.metric_id || value.binding_label || value.statement || value.summary || value.title || JSON.stringify(value));
+};
+
+const safeJson = (value) => {
+  try {
+    const text = sanitizeText(JSON.stringify(value, null, 2));
+    return text.length > MAX_APPENDIX_CHARS ? `${text.slice(0, MAX_APPENDIX_CHARS)}\n...truncated for PDF length...` : text;
+  } catch (error) {
+    return `Unable to serialize export payload: ${error.message}`;
+  }
+};
+
+const ensureRoom = (pdf, y, spaceNeeded = PAGE.lineHeight) => {
+  if (y + spaceNeeded <= PAGE.height - PAGE.marginY) return y;
+  pdf.addPage();
+  return PAGE.marginY;
+};
+
+const writeLines = (pdf, lines, y, fontSize = 10, options = {}) => {
+  let nextY = y;
+  pdf.setFont('helvetica', options.bold ? 'bold' : 'normal');
+  pdf.setFontSize(fontSize);
+  pdf.setTextColor(options.color || 26, options.color || 32, options.color || 44);
+
+  lines.forEach((line) => {
+    nextY = ensureRoom(pdf, nextY);
+    pdf.text(line, PAGE.marginX + (options.indent || 0), nextY);
+    nextY += PAGE.lineHeight;
+  });
+
+  pdf.setTextColor(26, 32, 44);
+  return nextY;
+};
+
+const writeParagraph = (pdf, text, y, fontSize = 10, options = {}) => {
+  const safeText = sanitizeText(text);
+  if (!safeText) return y;
+  const maxWidth = CONTENT_WIDTH - (options.indent || 0);
+  const lines = pdf.splitTextToSize(safeText, maxWidth);
+  return writeLines(pdf, lines, y, fontSize, options);
+};
+
+const writeSection = (pdf, title, y) => {
+  let nextY = ensureRoom(pdf, y + 8, 28);
+  pdf.setDrawColor(218, 226, 238);
+  pdf.setLineWidth(0.7);
+  pdf.line(PAGE.marginX, nextY - 11, PAGE.width - PAGE.marginX, nextY - 11);
+  pdf.setFont('helvetica', 'bold');
+  pdf.setFontSize(14);
+  pdf.setTextColor(16, 33, 58);
+  pdf.text(sanitizeText(title), PAGE.marginX, nextY);
+  pdf.setTextColor(26, 32, 44);
+  return nextY + 18;
+};
+
+const writeSubsection = (pdf, title, y) => {
+  const nextY = ensureRoom(pdf, y, 18);
+  pdf.setFont('helvetica', 'bold');
+  pdf.setFontSize(11);
+  pdf.text(sanitizeText(title), PAGE.marginX, nextY);
+  return nextY + 14;
+};
+
+const writeKeyValue = (pdf, key, value, y) => {
+  const label = sanitizeText(key);
+  const text = labelForValue(value);
+  if (!text) return y;
+  return writeParagraph(pdf, `${label}: ${text}`, y);
+};
+
+const writeList = (pdf, items, y, emptyText = 'None recorded.') => {
+  if (!Array.isArray(items) || items.length === 0) {
+    return writeParagraph(pdf, emptyText, y, 10, { color: 92 });
+  }
+
+  let nextY = y;
+  items.forEach((item) => {
+    nextY = writeParagraph(pdf, `- ${labelForValue(item)}`, nextY);
+  });
+  return nextY;
+};
+
+const writeRef = (pdf, title, ref, y) => {
+  if (!ref) return y;
+  let nextY = writeSubsection(pdf, title, y);
+  nextY = writeKeyValue(pdf, 'Label', labelForRef(ref), nextY);
+  nextY = writeKeyValue(pdf, 'Field', ref.field, nextY);
+  nextY = writeKeyValue(pdf, 'Aggregation', ref.default_aggregation, nextY);
+  nextY = writeKeyValue(pdf, 'Binding confidence', ref.semantic_binding_confidence ?? ref.confidence, nextY);
+  nextY = writeKeyValue(pdf, 'Binding reason', ref.semantic_binding_reason ?? ref.reason, nextY);
+  nextY = writeList(pdf, ref.semantic_role_warnings || ref.decision_semantics?.unresolved_reasons, nextY, 'No warnings recorded.');
+  return nextY + 4;
+};
+
+const writeCapabilityState = (pdf, capabilityState, y) => {
+  if (!capabilityState || typeof capabilityState !== 'object') return y;
+  let nextY = y;
+  Object.entries(capabilityState)
+    .filter(([, value]) => value && typeof value === 'object' && !Array.isArray(value))
+    .forEach(([key, value]) => {
+      nextY = writeParagraph(
+        pdf,
+        `${readableKey(key)}: ${value.status || 'unknown'} - ${value.reason || ''}`,
+        nextY
+      );
+    });
+  return nextY;
+};
+
+const addFooter = (pdf) => {
+  const pageCount = pdf.getNumberOfPages();
+  for (let i = 1; i <= pageCount; i += 1) {
+    pdf.setPage(i);
+    pdf.setFont('helvetica', 'normal');
+    pdf.setFontSize(8.5);
+    pdf.setTextColor(95, 104, 122);
+    pdf.text(`Decision Intelligence Export | Page ${i} of ${pageCount}`, PAGE.marginX, PAGE.height - 22);
+  }
+  pdf.setTextColor(26, 32, 44);
+};
+
+const createPdf = (title, subtitle) => {
+  const pdf = new jsPDF({ unit: 'pt', format: 'letter', orientation: 'portrait' });
+  let y = PAGE.marginY;
+
+  pdf.setFont('helvetica', 'bold');
+  pdf.setFontSize(18);
+  pdf.setTextColor(16, 33, 58);
+  pdf.text(sanitizeText(title), PAGE.marginX, y);
+  y += 22;
+
+  pdf.setFont('helvetica', 'normal');
+  pdf.setFontSize(9.5);
+  pdf.setTextColor(95, 104, 122);
+  pdf.text(`Generated: ${formatTimestamp()}${subtitle ? ` | ${sanitizeText(subtitle)}` : ''}`, PAGE.marginX, y);
+  y += 22;
+  pdf.setTextColor(26, 32, 44);
+
+  return { pdf, y };
+};
+
+const savePdf = (pdf, name) => {
+  addFooter(pdf);
+  pdf.save(`${name}_${fileDate()}.pdf`);
+};
+
+const writeWorkspacePreview = (pdf, wp, y) => {
+  let nextY = writeSection(pdf, 'Decision Workspace Preview', y);
+  nextY = writeKeyValue(pdf, 'Title', wp.title, nextY);
+  nextY = writeKeyValue(pdf, 'Status', wp.status_label || wp.status, nextY);
+  nextY = writeKeyValue(pdf, 'Summary', wp.decision_kickoff?.summary || wp.scope_summary || wp.summary, nextY);
+  nextY = writeKeyValue(pdf, 'Objective', wp.objective_metric, nextY);
+  nextY = writeKeyValue(pdf, 'Time horizon', wp.time_horizon, nextY);
+
+  nextY = writeSubsection(pdf, 'Levers', nextY + 4);
+  nextY = writeList(pdf, wp.levers, nextY);
+  nextY = writeSubsection(pdf, 'Segments', nextY + 4);
+  nextY = writeList(pdf, wp.segment_dimensions, nextY);
+  nextY = writeSubsection(pdf, 'Guardrails', nextY + 4);
+  nextY = writeList(pdf, wp.guardrails, nextY);
+
+  const unresolved = wp.drafting?.prompt_matches?.unresolved_mappings || wp.unresolved_mappings || [];
+  nextY = writeSubsection(pdf, 'Unresolved Semantic Mappings', nextY + 4);
+  if (!unresolved.length) {
+    nextY = writeParagraph(pdf, 'No unresolved mappings were reported.', nextY, 10, { color: 92 });
+  } else {
+    unresolved.forEach((mapping) => {
+      const candidates = Array.isArray(mapping.candidate_labels) ? mapping.candidate_labels.join(', ') : '';
+      nextY = writeParagraph(
+        pdf,
+        `- ${mapping.mapping_type || 'mapping'}: ${mapping.term || mapping.label || mapping.field || 'unknown'} | ${mapping.reason || 'No reason provided.'}${candidates ? ` | Candidates: ${candidates}` : ''}`,
+        nextY
+      );
+    });
+  }
+
+  nextY = writeSection(pdf, 'Readiness And Capability Boundary', nextY + 6);
+  const readiness = wp.decision_readiness || wp.readiness || {};
+  nextY = writeKeyValue(pdf, 'Readiness state', readiness.readiness_state || wp.readiness_state, nextY);
+  nextY = writeKeyValue(pdf, 'Truth boundary', readiness.truth_boundary || wp.truth_boundary, nextY);
+  nextY = writeList(pdf, readiness.allowed_next_actions || wp.allowed_next_actions, nextY, 'No backend-approved next actions were reported.');
+  nextY = writeCapabilityState(pdf, wp.capability_state || readiness.capability_state, nextY + 4);
+
+  return nextY;
+};
+
+const writeAnalysisSummary = (pdf, content, y) => {
+  let nextY = writeSection(pdf, 'Workspace Analysis Summary', y);
+  nextY = writeKeyValue(pdf, 'Headline', content?.summary?.headline || content?.headline, nextY);
+  nextY = writeKeyValue(pdf, 'Summary', content?.summary?.content || content?.summary, nextY);
+  nextY = writeKeyValue(pdf, 'Truthfulness note', content?.truthfulness_note, nextY);
+
+  nextY = writeSubsection(pdf, 'Diagnostic Items', nextY + 4);
+  if (Array.isArray(content?.items) && content.items.length > 0) {
+    content.items.forEach((item, index) => {
+      const label = labelForValue(item.label || item.statement || item.headline || item.title || item);
+      const detail = item.description || item.summary || item.reason || item.category;
+      nextY = writeParagraph(pdf, `${index + 1}. ${label}${detail ? ` - ${detail}` : ''}`, nextY);
+    });
+  } else {
+    nextY = writeParagraph(pdf, 'No diagnostic details were reported.', nextY, 10, { color: 92 });
+  }
+
+  nextY = writeSubsection(pdf, 'Missing Inputs', nextY + 4);
+  nextY = writeList(pdf, content?.missing_inputs, nextY, 'No missing inputs reported.');
+  return nextY;
+};
+
+const writeAnswerArtifact = (pdf, content, y) => {
+  let nextY = writeSection(pdf, 'Grounded Data Result', y);
+  nextY = writeKeyValue(pdf, 'Metric', content?.metric?.label || content?.metric?.name || content?.fieldsUsed?.value, nextY);
+  nextY = writeKeyValue(pdf, 'Summary value', content?.summary?.value_formatted || content?.summary?.value, nextY);
+  nextY = writeKeyValue(pdf, 'Top result', content?.top_group?.label, nextY);
+  nextY = writeKeyValue(pdf, 'Message', content?.message, nextY);
+
+  if (Array.isArray(content?.rows) && content.rows.length > 0) {
+    nextY = writeSubsection(pdf, 'Rows', nextY + 4);
+    content.rows.slice(0, 40).forEach((row) => {
+      const label = row.group_label || (row.group ? Object.values(row.group).join(' | ') : 'Segment');
+      nextY = writeParagraph(pdf, `- ${label}: ${row.value_formatted || row.value}`, nextY);
+    });
+  }
+  return nextY;
+};
+
+const writeChartArtifact = (pdf, content, y) => {
+  let nextY = writeSection(pdf, 'Chart Result', y);
+  nextY = writeKeyValue(pdf, 'Chart type', content?.chartType, nextY);
+  nextY = writeKeyValue(pdf, 'Explanation', content?.explanation, nextY);
+
+  const chartData = content?.chartData;
+  if (Array.isArray(chartData?.labels) && Array.isArray(chartData?.datasets)) {
+    nextY = writeSubsection(pdf, 'Chart Data', nextY + 4);
+    const firstDataset = chartData.datasets[0] || {};
+    chartData.labels.slice(0, 60).forEach((label, index) => {
+      nextY = writeParagraph(pdf, `- ${label}: ${firstDataset.data?.[index] ?? ''}`, nextY);
+    });
+  }
+  return nextY;
+};
+
+export const generateDecisionArtifactPdf = ({
+  artifact,
+  contextSessionState,
+  contextCapabilityState,
+  contextDecisionReadiness,
+}) => {
+  if (!artifact) return;
+
+  const { pdf, y: startY } = createPdf('Decision Intelligence Result', artifact.type || 'artifact');
+  let y = startY;
+  const content = artifact.content || artifact;
+
+  y = writeSection(pdf, 'Artifact Metadata', y);
+  y = writeKeyValue(pdf, 'Type', artifact.type, y);
+  y = writeKeyValue(pdf, 'Source', artifact.source, y);
+  y = writeKeyValue(pdf, 'Mode', artifact.mode, y);
+
+  if (artifact.type === 'workspace_preview') {
+    y = writeWorkspacePreview(pdf, content, y + 4);
+  } else if (artifact.type === 'workspace_analysis_summary') {
+    y = writeAnalysisSummary(pdf, content, y + 4);
+  } else if (artifact.type === 'answer') {
+    y = writeAnswerArtifact(pdf, content, y + 4);
+  } else if (artifact.type === 'chart') {
+    y = writeChartArtifact(pdf, content, y + 4);
+  } else {
+    y = writeSection(pdf, 'Artifact Content', y + 4);
+    y = writeParagraph(pdf, safeJson(content), y, 8.5);
+  }
+
+  const responseState = {
+    contextSessionState,
+    contextCapabilityState,
+    contextDecisionReadiness,
+  };
+  y = writeSection(pdf, 'Raw Contract Snapshot', y + 6);
+  writeParagraph(pdf, safeJson({ artifact, responseState }), y, 8.2);
+
+  savePdf(pdf, 'decision_ai_result');
+};
+
+export const generateDecisionWorkspacePdf = ({ workspace, analysis }) => {
+  if (!workspace) return;
+
+  const { pdf, y: startY } = createPdf('Decision Workspace Export', workspace.workspace_id || workspace.status);
+  let y = startY;
+
+  y = writeSection(pdf, 'Workspace Overview', y);
+  y = writeKeyValue(pdf, 'Title', workspace.title || 'Untitled Decision Workspace', y);
+  y = writeKeyValue(pdf, 'Workspace ID', workspace.workspace_id, y);
+  y = writeKeyValue(pdf, 'Status', workspace.status, y);
+  y = writeKeyValue(pdf, 'Prepared', formatTimestamp(workspace.created_at), y);
+  y = writeKeyValue(pdf, 'Decision prompt', workspace.decision_prompt, y);
+  y = writeKeyValue(pdf, 'Scope summary', workspace.scope_summary, y);
+
+  const scope = workspace.decision_scope || {};
+  const objective = scope.objective || {};
+  y = writeSection(pdf, 'Success Objective', y + 4);
+  y = writeKeyValue(pdf, 'Statement', objective.statement, y);
+  y = writeKeyValue(pdf, 'Direction', objective.direction, y);
+  y = writeKeyValue(pdf, 'Target', objective.target, y);
+  y = writeKeyValue(pdf, 'Time horizon', objective.time_horizon?.label || objective.time_horizon, y);
+  y = writeRef(pdf, 'Objective Metric', objective.metric_ref, y + 4);
+
+  y = writeSection(pdf, 'Strategic Levers', y + 4);
+  if (Array.isArray(scope.levers) && scope.levers.length > 0) {
+    scope.levers.forEach((lever, index) => {
+      y = writeSubsection(pdf, `${index + 1}. ${lever.label || 'Lever'}`, y);
+      y = writeKeyValue(pdf, 'Type', lever.lever_type, y);
+      y = writeKeyValue(pdf, 'Description', lever.description, y);
+      y = writeKeyValue(pdf, 'Desired change', lever.desired_change, y);
+      y = writeKeyValue(pdf, 'Binding status', lever.binding?.status, y);
+      y = writeRef(pdf, 'Binding', lever.binding?.metric_ref || lever.binding?.dimension_ref, y + 2);
+    });
+  } else {
+    y = writeParagraph(pdf, 'No strategic levers are currently defined.', y, 10, { color: 92 });
+  }
+
+  y = writeSection(pdf, 'Guardrails', y + 4);
+  if (Array.isArray(scope.constraints) && scope.constraints.length > 0) {
+    scope.constraints.forEach((constraint, index) => {
+      y = writeSubsection(pdf, `${index + 1}. ${constraint.label || 'Guardrail'}`, y);
+      y = writeKeyValue(pdf, 'Hardness', constraint.hardness, y);
+      y = writeKeyValue(pdf, 'Condition', constraint.condition, y);
+      y = writeKeyValue(pdf, 'Rationale', constraint.rationale, y);
+      y = writeKeyValue(pdf, 'Binding status', constraint.binding?.status, y);
+      y = writeRef(pdf, 'Binding', constraint.binding?.metric_ref || constraint.binding?.dimension_ref, y + 2);
+    });
+  } else {
+    y = writeParagraph(pdf, 'No guardrails are currently defined.', y, 10, { color: 92 });
+  }
+
+  const scopedContext = workspace.scoped_context || {};
+  y = writeSection(pdf, 'Scoped Context', y + 4);
+  y = writeSubsection(pdf, 'Relevant Metrics', y);
+  y = writeList(pdf, scopedContext.relevant_metrics, y, 'No relevant metrics recorded.');
+  y = writeSubsection(pdf, 'Relevant Dimensions', y + 4);
+  y = writeList(pdf, scopedContext.relevant_dimensions, y, 'No relevant dimensions recorded.');
+  y = writeSubsection(pdf, 'Comparison Dimensions', y + 4);
+  y = writeList(pdf, scopedContext.comparison_dimensions, y, 'No comparison dimensions recorded.');
+  y = writeKeyValue(pdf, 'Time context', scopedContext.time_context, y + 4);
+  y = writeKeyValue(pdf, 'Period context', scopedContext.period_context, y);
+
+  y = writeSection(pdf, 'Assumptions And Information Gaps', y + 4);
+  y = writeSubsection(pdf, 'Assumptions', y);
+  y = writeList(pdf, workspace.assumptions, y, 'No assumptions recorded.');
+  y = writeSubsection(pdf, 'Information Gaps', y + 4);
+  y = writeList(pdf, workspace.unknowns, y, 'No information gaps recorded.');
+
+  const readiness = workspace.decision_readiness || workspace.readiness || {};
+  y = writeSection(pdf, 'Readiness And Capabilities', y + 4);
+  y = writeKeyValue(pdf, 'Readiness state', readiness.readiness_state || workspace.status, y);
+  y = writeKeyValue(pdf, 'Truth boundary', readiness.truth_boundary, y);
+  y = writeList(pdf, readiness.allowed_next_actions, y, 'No allowed next actions recorded.');
+  y = writeCapabilityState(pdf, readiness.capability_state || workspace.readiness?.capability_state, y + 4);
+
+  if (analysis) {
+    y = writeSection(pdf, 'Analysis Results', y + 4);
+    y = writeKeyValue(pdf, 'Summary', analysis.summary, y);
+    y = writeKeyValue(pdf, 'Truthfulness note', analysis.truthfulness_note, y);
+    y = writeSubsection(pdf, 'Scoped Diagnostics', y + 4);
+    if (Array.isArray(analysis.scoped_diagnostics) && analysis.scoped_diagnostics.length > 0) {
+      analysis.scoped_diagnostics.forEach((diagnostic, index) => {
+        y = writeParagraph(pdf, `${index + 1}. ${diagnostic.summary || labelForValue(diagnostic)}`, y);
+        y = writeKeyValue(pdf, 'Status', diagnostic.status, y);
+        y = writeKeyValue(pdf, 'Evidence', diagnostic.evidence, y);
+      });
+    } else {
+      y = writeParagraph(pdf, labelForValue(analysis.scoped_diagnostics) || 'No scoped diagnostics were generated.', y, 10, { color: 92 });
+    }
+  }
+
+  y = writeSection(pdf, 'Raw Contract Snapshot', y + 6);
+  writeParagraph(pdf, safeJson({ workspace, analysis }), y, 8.2);
+
+  savePdf(pdf, 'decision_workspace_export');
+};

--- a/generated_docs/decision_intelligence_overview_2026-05-12.html
+++ b/generated_docs/decision_intelligence_overview_2026-05-12.html
@@ -1,0 +1,490 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Decision Intelligence Overview</title>
+  <style>
+    @page {
+      size: Letter;
+      margin: 0.72in 0.72in 0.8in;
+    }
+
+    :root {
+      --ink: #152034;
+      --muted: #5c687a;
+      --rule: #d9e0ea;
+      --soft: #f5f7fb;
+      --soft-2: #eef3f8;
+      --accent: #2454a6;
+      --accent-2: #0f766e;
+      --warn: #9a5b00;
+    }
+
+    body {
+      margin: 0;
+      color: var(--ink);
+      font-family: "Segoe UI", Arial, sans-serif;
+      font-size: 10.4pt;
+      line-height: 1.52;
+      background: white;
+    }
+
+    h1, h2, h3 {
+      line-height: 1.18;
+      margin: 0;
+      color: #0d1726;
+    }
+
+    h1 {
+      font-size: 30pt;
+      letter-spacing: 0;
+      margin-bottom: 0.18in;
+    }
+
+    h2 {
+      font-size: 17pt;
+      margin: 0.32in 0 0.11in;
+      padding-top: 0.04in;
+      border-top: 1px solid var(--rule);
+    }
+
+    h3 {
+      font-size: 12.5pt;
+      margin: 0.2in 0 0.06in;
+    }
+
+    p {
+      margin: 0 0 0.12in;
+    }
+
+    ul {
+      margin: 0.04in 0 0.14in 0.22in;
+      padding: 0;
+    }
+
+    li {
+      margin: 0 0 0.05in;
+    }
+
+    table {
+      border-collapse: collapse;
+      width: 100%;
+      margin: 0.12in 0 0.18in;
+      font-size: 9.4pt;
+    }
+
+    th {
+      text-align: left;
+      color: #10213a;
+      background: var(--soft-2);
+      border: 1px solid var(--rule);
+      padding: 7px 8px;
+      vertical-align: top;
+    }
+
+    td {
+      border: 1px solid var(--rule);
+      padding: 7px 8px;
+      vertical-align: top;
+    }
+
+    code {
+      font-family: Consolas, "Courier New", monospace;
+      font-size: 9.4pt;
+      color: #10213a;
+      background: #eef2f7;
+      padding: 1px 4px;
+      border-radius: 4px;
+    }
+
+    .cover {
+      min-height: 8.1in;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      page-break-after: always;
+    }
+
+    .eyebrow {
+      color: var(--accent);
+      font-size: 10pt;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      margin-bottom: 0.12in;
+    }
+
+    .subtitle {
+      font-size: 15pt;
+      line-height: 1.4;
+      color: #34445b;
+      max-width: 6.7in;
+      margin-bottom: 0.28in;
+    }
+
+    .meta {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 0.1in;
+      max-width: 6.5in;
+      margin-top: 0.1in;
+    }
+
+    .meta div, .callout, .note, .flow, .example {
+      background: var(--soft);
+      border: 1px solid var(--rule);
+      border-radius: 7px;
+      padding: 0.12in 0.14in;
+    }
+
+    .meta strong {
+      display: block;
+      font-size: 8.5pt;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      color: var(--muted);
+      margin-bottom: 2px;
+    }
+
+    .callout {
+      border-left: 5px solid var(--accent);
+      margin: 0.16in 0 0.2in;
+    }
+
+    .note {
+      border-left: 5px solid var(--accent-2);
+      margin: 0.14in 0 0.18in;
+    }
+
+    .warning {
+      border-left-color: var(--warn);
+    }
+
+    .flow {
+      margin: 0.14in 0 0.18in;
+      padding: 0.13in;
+    }
+
+    .flow-row {
+      display: grid;
+      grid-template-columns: 1fr 1fr 1fr 1fr;
+      gap: 0.08in;
+      align-items: stretch;
+    }
+
+    .flow-step {
+      background: white;
+      border: 1px solid var(--rule);
+      border-radius: 6px;
+      padding: 0.1in;
+      min-height: 0.74in;
+    }
+
+    .flow-step strong {
+      display: block;
+      color: var(--accent);
+      margin-bottom: 0.03in;
+    }
+
+    .example {
+      margin: 0.12in 0 0.18in;
+      background: #fbfcfe;
+    }
+
+    .example-title {
+      font-weight: 700;
+      color: var(--accent);
+      margin-bottom: 0.04in;
+    }
+
+    .small {
+      font-size: 9.1pt;
+      color: var(--muted);
+    }
+
+    .page-break {
+      page-break-before: always;
+    }
+
+    .toc {
+      page-break-after: always;
+    }
+
+    .toc table {
+      font-size: 10pt;
+    }
+
+    .footer-note {
+      margin-top: 0.25in;
+      font-size: 9pt;
+      color: var(--muted);
+    }
+  </style>
+</head>
+<body>
+  <section class="cover">
+    <div class="eyebrow">AI Tool - Decision Intelligence</div>
+    <h1>How The Decision Intelligence Feature Works</h1>
+    <p class="subtitle">
+      A hybrid product and engineering narrative for managers, developers, and reviewers. This document explains the AI chat modes, Decisions workspace, semantic role system, readiness contract, observational-analysis boundary, and current implementation status.
+    </p>
+    <div class="meta">
+      <div><strong>Generated</strong>May 12, 2026</div>
+      <div><strong>Audience</strong>Product managers, technical leads, frontend engineers, backend engineers, and implementation reviewers</div>
+      <div><strong>Current Product Line</strong>Decision Intelligence V3</div>
+      <div><strong>Current Boundary</strong>Decision support and observational analysis only; no causal simulation, optimization engine, autonomous decisioning, or final recommendation engine</div>
+    </div>
+    <p class="footer-note">
+      This is a standalone explanatory artifact. It is intentionally not part of the active project documentation tree and should be treated as a periodic snapshot of how the feature works at generation time.
+    </p>
+  </section>
+
+  <section class="toc">
+    <h2>Contents</h2>
+    <table>
+      <tr><td>1</td><td>Executive Narrative</td><td>The product idea and what the feature is meant to accomplish.</td></tr>
+      <tr><td>2</td><td>The User Experience Model</td><td>How AI Chat and the Decisions workspace fit together.</td></tr>
+      <tr><td>3</td><td>Inquire, Explore, And Decide</td><td>The three AI sections and how the backend routes user intent.</td></tr>
+      <tr><td>4</td><td>The Decisions Workspace</td><td>The structured decision frame, readiness, diagnostics, and workspace continuity.</td></tr>
+      <tr><td>5</td><td>Semantic Role Strengthening</td><td>How objectives, levers, guardrails, segments, confidence, and unresolved mappings work.</td></tr>
+      <tr><td>6</td><td>Architecture And Contracts</td><td>Backend services, frontend surfaces, endpoints, artifacts, session state, and action flow.</td></tr>
+      <tr><td>7</td><td>Current Limits And Phase 3 Direction</td><td>What is deliberately unsupported today and what comes next.</td></tr>
+      <tr><td>8</td><td>Concrete Dataset Example</td><td>A practical example using the current testing dataset.</td></tr>
+    </table>
+  </section>
+
+  <h2>Executive Narrative</h2>
+  <p>
+    The Decision Intelligence feature is the part of the app that turns a business question over a dataset into a structured decision-support workflow. It is not just a chatbot bolted onto analytics. The intended product behavior is that a user can ask factual questions, explore data visually, and then frame a decision in terms of an objective, controllable levers, guardrails, segments, assumptions, blockers, and evidence. The system keeps the experience conversational, but the implementation is contract-driven underneath so the UI can remain truthful about what the backend has actually understood.
+  </p>
+  <p>
+    In its current V3 form, Decision Intelligence is built around two connected surfaces. The first surface is the AI Chat experience, where the user enters natural-language questions and chooses between Inquire, Explore, and Decide. The second surface is the Decisions workspace, where a decision frame can be inspected, corrected in future phases, and analyzed against the active dataset. The important product distinction is that AI Chat is the front door and the Decisions workspace is the structured operating room. Chat is optimized for fast interpretation and response; the workspace is optimized for durable decision state, readiness, and inspectability.
+  </p>
+  <p>
+    The feature currently supports grounded data questions, exploratory analysis, decision-frame drafting, action handling, chat-to-workspace continuity, readiness checks, semantic-role metadata, and observational workspace analysis. It deliberately does not perform causal simulation, optimization, autonomous decisioning, or final recommendations. That boundary is not a temporary UI wording issue. It is part of the backend contract. The system can say what the data shows, what has been framed, what is missing, and what evidence is available. It should not claim to know what will happen if the business changes a lever unless a later causal or experimental layer is explicitly implemented.
+  </p>
+  <div class="callout">
+    <p>
+      The core product promise today is: "Help the user turn messy business intent into a structured, inspectable, readiness-aware decision frame, then support that frame with grounded observational evidence."
+    </p>
+  </div>
+
+  <h2>The User Experience Model</h2>
+  <p>
+    The user-facing experience starts in AI Chat. The UI exposes three modes: Inquire, Explore, and Decide. These are not three separate chatbots. They are user-facing mode labels over a shared backend chat contract. Every chat turn is sent with the user message, conversation history, session state, the resolved dataset, and the semantic model. The backend decides how to interpret the turn and returns an assistant message, optional artifacts, suggested actions, readiness metadata, capability metadata, and updated session state.
+  </p>
+  <p>
+    The result of that design is that the app can keep a conversation going without pretending the model is remembering private state on its own. The frontend carries session state forward, and the backend treats that state as part of the input contract. When a turn creates a draft decision workspace, the workspace is returned in the response and preserved in session state. When the user later clicks an action such as "Open Workspace" or "Analyze Workspace", the action is scoped to the message or artifact that created it, not accidentally applied to a newer unrelated card.
+  </p>
+  <p>
+    The Decisions workspace becomes relevant when the user is no longer just asking "what does this metric show?" and starts asking "what should we evaluate?" or "how should we frame this tradeoff?" In the workspace, the app shows the decision objective, strategic levers, guardrails, scoped metrics and dimensions, readiness status, capability boundaries, assumptions, unknowns, and analysis results. The workspace is meant to make the AI's interpretation reviewable. A manager should be able to see the business logic. A developer should be able to trace it back to contract fields.
+  </p>
+
+  <div class="flow">
+    <div class="flow-row">
+      <div class="flow-step"><strong>User Prompt</strong>Natural language arrives through AI Chat with the current dataset and semantic model.</div>
+      <div class="flow-step"><strong>Mode Routing</strong>The backend classifies the turn as ask, explore, or decide using intent rules and session context.</div>
+      <div class="flow-step"><strong>Contract Response</strong>The backend returns message text, artifacts, actions, readiness, capability state, and session state.</div>
+      <div class="flow-step"><strong>Workspace Continuity</strong>Decision artifacts can open or hydrate the Decisions workspace with the exact scoped draft.</div>
+    </div>
+  </div>
+
+  <h2>Inquire, Explore, And Decide</h2>
+  <p>
+    Inquire is the user-facing label for the backend's ask-style behavior. It is best thought of as grounded factual analysis. A user can ask what the data contains, what a field means in context, or a simple question that does not demand a visualization or decision frame. The backend may still return structured metadata, but the experience is primarily answer-oriented. Inquire should not quietly create a decision workspace unless the prompt contains decision intent or the active session context makes a decision follow-up obvious.
+  </p>
+  <p>
+    Explore is the visual and analytic discovery mode. It is triggered by terms such as chart, graph, visualize, breakdown, trend, over time, compare, versus, top, highest, lowest, and related analytic language. Explore uses the dataset and semantic model to produce grounded metric or dimension analysis. The user can ask for a metric broken down by a dimension, a top result, a trend, or a grouped comparison. The current UI can render chart artifacts and data result artifacts, and the assistant message explains the grounded result in plain language.
+  </p>
+  <p>
+    Decide is the strategic framing mode. It is triggered by decision language such as "should we", "how should we", "what should we do", "improve", "grow", "reduce", "while protecting", "guardrail", "constraint", "tradeoff", and similar phrasing. In Decide mode, the backend does not simply answer the question as if it were a normal metric lookup. It tries to draft a decision workspace. That draft identifies what the user is trying to optimize or protect, which fields are potential levers, which fields are guardrails, and which dimensions should segment the analysis.
+  </p>
+  <p>
+    These modes are intentionally connected. A user might begin in Inquire by asking what columns are available, move to Explore by asking for gross margin by channel, and then move to Decide by asking how to grow revenue while protecting gross margin and returns. The product value comes from carrying context forward while keeping each response honest about its current level of certainty.
+  </p>
+
+  <table>
+    <tr><th>Mode In The UI</th><th>Backend Shape</th><th>Typical User Intent</th><th>Primary Output</th></tr>
+    <tr>
+      <td>Inquire</td>
+      <td><code>ask</code></td>
+      <td>Grounded question, explanation, basic factual answer, or non-visual dataset inquiry.</td>
+      <td>Assistant answer and optional simple artifacts.</td>
+    </tr>
+    <tr>
+      <td>Explore</td>
+      <td><code>explore</code></td>
+      <td>Chart, trend, breakdown, ranking, comparison, or visual discovery.</td>
+      <td>Grounded analytic result, chart or data artifact, and updated session context.</td>
+    </tr>
+    <tr>
+      <td>Decide</td>
+      <td><code>decide</code></td>
+      <td>Business decision, objective, lever, guardrail, constraint, or tradeoff framing.</td>
+      <td>Decision workspace preview, readiness state, actions, assumptions, blockers, and capability boundaries.</td>
+    </tr>
+  </table>
+
+  <h3>Why Inquire And Explore Are Different</h3>
+  <p>
+    A common confusion is that Inquire and Explore can both answer questions about data. The difference is not whether data is involved. The difference is the shape of the requested work. "What is gross_margin_pct by channel?" is analytic and grouped, so it routes naturally to Explore. "What columns are in this dataset?" or "What does return_rate_pct represent in this context?" is more likely to be an Inquire-style interaction. Explore produces a data result or visualization; Inquire produces a grounded answer.
+  </p>
+
+  <h3>Why Decide Is Not Just A Bigger Explore</h3>
+  <p>
+    Decide asks the system to interpret intent across multiple semantic roles. A prompt like "How should we grow revenue next quarter using marketing_spend and discount_pct while protecting gross_margin_pct and return_rate_pct?" contains an objective, levers, guardrails, and a time horizon. That is more than a chart request. The backend needs to treat revenue as a success objective, marketing spend and discount percent as potential controllable levers, gross margin and return rate as constraints or guardrails, and any segmentation terms as dimensions for follow-up analysis.
+  </p>
+
+  <h2>The Decisions Workspace</h2>
+  <p>
+    The Decisions workspace is the structured representation of the decision that the AI has drafted or the user has built. It is the part of the feature that makes decision support inspectable. Instead of leaving the user's prompt as an opaque paragraph, the backend creates a workspace object with a decision scope. That scope contains an objective, levers, constraints or guardrails, relevant metrics, relevant dimensions, comparison dimensions, temporal context, assumptions, unknowns, readiness, and drafting metadata.
+  </p>
+  <p>
+    In the workspace, the objective answers the question "what are we trying to improve, protect, reduce, or understand?" Levers answer "what might the business be able to change?" Guardrails answer "what should not be harmed while pursuing the objective?" Segments answer "where should we compare outcomes?" Time context answers "over what period or grain should this be understood?" These elements are not merely labels. They determine whether the workspace is ready for observational analysis and what evidence should be considered relevant.
+  </p>
+  <p>
+    Readiness is backend-owned. The UI renders it, but it should not invent it. Current readiness fields include whether the objective is ready, whether the lever set is usable, whether constraints are defined, whether the scope is complete enough, and whether missing inputs block analysis. The backend also returns allowed next actions. A structurally ready frame may allow "Analyze Workspace" and "Open Workspace"; an incomplete frame may allow "Show Blockers" and "Open Workspace" but block analysis. This prevents the interface from inviting the user to run analysis when the backend knows the decision frame is incomplete.
+  </p>
+  <p>
+    The workspace also renders the capability state. Observational analysis can be supported and available when the frame is structurally ready. Workspace opening can be supported when a draft workspace exists. Simulation, optimization, autonomous decisioning, and final recommendation are unsupported in the current runtime. The product should surface that clearly, especially when the user's prompt explicitly asks for one of those unsupported capabilities.
+  </p>
+
+  <div class="note warning">
+    <p>
+      The Decisions workspace should be understood as a decision-support workspace, not an automated decision maker. Its current job is to organize intent and evidence. It should not be described as selecting the final business action.
+    </p>
+  </div>
+
+  <h2>Semantic Role Strengthening</h2>
+  <p>
+    Phase 2 added the semantic foundation that makes the decision layer more trustworthy. Before this phase, the system could match prompt terms to fields or semantic objects, but it had less explicit structure around the role a matched object was playing. After Phase 2, semantic metrics and dimensions can carry decision-aware metadata. A metric can be marked as a plausible objective, lever, or guardrail. A dimension can be marked as a segment, comparison, or temporal candidate. These roles are additive, which means older semantic models remain compatible.
+  </p>
+  <p>
+    The metadata includes aliases, business terms, polarity, controllability, confidence, confidence reasons, and unresolved review reasons. This matters because business language rarely matches column names perfectly. A user may say "margin" while the dataset uses <code>gross_margin_pct</code>. A user may say "returns" while the dataset uses <code>return_rate_pct</code>. The role system gives the backend a conservative way to explain why a field was selected and how confident the system is in that selection.
+  </p>
+  <p>
+    Conservative confidence is a design choice. The app should prefer saying "this looks like the right binding, but here is the warning" over silently treating a weak match as certain. If a prompt term has no safe match, the draft can include unresolved mapping details. If multiple candidates are close, the backend can expose candidate labels. If a field is matched only as a raw dataset field rather than a semantic metric or dimension, the backend can warn that the binding is weaker. This is a key trust feature because it lets the user see where the AI's interpretation may need correction.
+  </p>
+  <p>
+    On the frontend, the SemanticRef component is responsible for rendering compact metric and dimension references with role metadata, confidence, warnings, and trace evidence. It is used in the AI Chat workspace preview and in the Decisions workspace. The current implementation also preserves fallback labels when a semantic reference is incomplete, so a human-readable draft value does not disappear simply because a perfect semantic binding is missing.
+  </p>
+
+  <table>
+    <tr><th>Decision Concept</th><th>Example Field In Current Test Dataset</th><th>Semantic Role Meaning</th></tr>
+    <tr><td>Objective</td><td><code>revenue</code></td><td>A success metric the user may want to grow or improve.</td></tr>
+    <tr><td>Lever</td><td><code>marketing_spend</code>, <code>discount_pct</code></td><td>A plausibly controllable input or business action area.</td></tr>
+    <tr><td>Guardrail</td><td><code>gross_margin_pct</code>, <code>return_rate_pct</code>, <code>stockout_days</code></td><td>A metric to protect, cap, or keep within a threshold while pursuing the objective.</td></tr>
+    <tr><td>Segment</td><td><code>region</code>, <code>channel</code>, <code>product_category</code></td><td>A dimension used to compare or slice evidence.</td></tr>
+    <tr><td>Temporal Context</td><td><code>month</code></td><td>A dimension used to establish time grain and observed period comparisons.</td></tr>
+  </table>
+
+  <h2>Architecture And Contracts</h2>
+  <p>
+    The backend AI chat contract is centered on two endpoints: a turn endpoint and an action endpoint. A chat turn accepts the user message, conversation history, session state, dataset, and semantic model. An action accepts an action id, action payload, and scoped session state. This separation matters because a message can propose actions, and those actions may be clicked later. The action should operate on the decision workspace and metadata that existed when the action was proposed, not on whatever happens to be globally current in the UI.
+  </p>
+  <p>
+    The primary backend coordinator for AI Chat is the decision chat service. It handles mode detection, analytics responses, decision workspace drafting, action contracts, readiness state, capability state, artifact creation, and session-state updates. The decision workspace service handles the creation of structured workspaces. It performs prompt-first drafting when the user gives a natural-language decision statement, resolves metrics and dimensions, annotates semantic bindings, records unresolved mappings, normalizes objective and lever objects, and evaluates readiness.
+  </p>
+  <p>
+    The frontend AI Chat shell sends turns to the backend, renders assistant messages and artifacts, stores session state, scopes actions to historical messages, and opens the Decisions workspace when the user chooses the relevant action. It also includes an artifact inspector panel so richer outputs such as workspace previews and workspace analysis summaries can be inspected outside the message bubble. The Decisions workspace view renders the structured workspace in a more durable format, including objective, levers, guardrails, scoped context, readiness, capability matrix, and analysis output.
+  </p>
+
+  <table>
+    <tr><th>Layer</th><th>Key Responsibility</th><th>Representative Implementation Area</th></tr>
+    <tr><td>Mode detection</td><td>Classifies prompt intent into ask, explore, or decide using keywords and active session context.</td><td><code>backend/decision_engine/mode_detection.py</code></td></tr>
+    <tr><td>Chat orchestration</td><td>Builds chat responses, artifacts, suggested actions, readiness, capability metadata, and action handling.</td><td><code>backend/decision_engine/chat_service.py</code></td></tr>
+    <tr><td>Workspace service</td><td>Creates decision workspaces, prompt-first drafts, semantic bindings, unresolved mappings, and readiness state.</td><td><code>backend/services/decision_workspace_service.py</code></td></tr>
+    <tr><td>AI Chat UI</td><td>Renders Inquire, Explore, Decide, artifacts, actions, inspector state, and chat-to-workspace continuity.</td><td><code>frontend/frontend/src/features/ai/AIShell.jsx</code></td></tr>
+    <tr><td>Workspace UI</td><td>Renders the structured decision frame, semantic references, readiness, capability boundaries, and diagnostics.</td><td><code>frontend/frontend/src/features/business/decision/DecisionWorkspaceView.jsx</code></td></tr>
+    <tr><td>Semantic reference UI</td><td>Shows metric and dimension identity, semantic role, confidence, warnings, and trace details.</td><td><code>frontend/frontend/src/features/business/decision/SemanticRef.jsx</code></td></tr>
+  </table>
+
+  <h3>The Action System</h3>
+  <p>
+    Actions make AI Chat behave like a workflow instead of a passive answer stream. Current decision actions include drafting a workspace, showing assumptions, showing blockers, analyzing a workspace, and opening a workspace. Each action has a contract that describes its intent, expected payload, and produced artifacts or state changes. This creates a path for the UI to present buttons confidently while still letting the backend decide whether an action is currently allowed.
+  </p>
+  <p>
+    The most important action from a continuity perspective is "Open Workspace". When the user clicks it, the frontend resolves the relevant draft workspace from the action response, top-level response fields, nested decision state, or session state, and then hydrates the Decisions destination. That is what turns a chat artifact into an actual workspace rather than a screenshot-like preview.
+  </p>
+
+  <h3>Artifacts</h3>
+  <p>
+    Artifacts are structured response objects that the UI can render with specialized components. Explore can produce chart or data result artifacts. Decide can produce a workspace preview artifact. Analyze Workspace can produce a workspace analysis summary artifact. The artifact type tells the frontend what renderer to use, while the artifact payload carries the data, readiness fields, and contextual details.
+  </p>
+  <p>
+    The workspace preview artifact is especially important. It contains the Decision Kickoff summary, understood objective, levers, segments, guardrails, readiness state, capability state, unsupported capabilities, semantic binding details, and unresolved mappings. It is designed to let the user decide whether the AI understood the frame before moving deeper into the Decisions workspace.
+  </p>
+
+  <h2>Reliability, Readiness, And Truth Boundaries</h2>
+  <p>
+    The reliability foundation added explicit backend fields so the UI does not need to infer capability from vague status strings. The response can include <code>decision_readiness</code>, <code>readiness_state</code>, <code>structural_readiness</code>, <code>blocked_state</code>, <code>allowed_next_actions</code>, <code>capability_state</code>, <code>unsupported_capabilities</code>, and <code>not_ready_for_recommendation</code>. These fields define what is available, what is blocked, what is unsupported, and why.
+  </p>
+  <p>
+    The truth boundary today is <code>observational_analysis_only</code>. That phrase should be taken literally. The app can summarize and rank observed evidence. It can explain that a field appears related to the current decision frame. It can expose data quality caveats. It can tell the user that requested simulation or optimization is unsupported. It cannot yet claim causal impact, forecast the result of a lever change, optimize a policy, or make a final recommendation.
+  </p>
+  <p>
+    This makes the current app more conservative than many AI demos, but it also makes it more defensible. A manager can use it to organize a decision discussion and find evidence. A developer can extend it without having to unwind misleading claims from the UI. A reviewer can inspect whether the response stayed inside its capability boundary.
+  </p>
+
+  <h2>Current Limits And Phase 3 Direction</h2>
+  <p>
+    The current system has strong foundations but still has deliberate gaps. The most important gap is correction. The system can now show semantic confidence, warnings, and unresolved mappings, but the next backend slice is to let users correct the decision frame deterministically. For example, if the system binds the wrong objective metric, the user should be able to replace that objective binding and have subsequent analysis use the corrected state. The correction should not be a free-form mutation of arbitrary state; it should be a validated action against a stable target path.
+  </p>
+  <p>
+    The second major Phase 3 direction is ranked observational evidence. Analyze Workspace should return richer ordered diagnostics with evidence, semantic coverage, data-quality caveats, assumptions, blockers, and limitations. The word "ranked" should mean diagnostic relevance, not a recommended action order. The system should be able to say which observed evidence is most relevant to the framed decision and why, while still avoiding causal or prescriptive claims.
+  </p>
+  <p>
+    There is also a minor frontend cleanup remaining from the Phase 2 review. The semantic reference integration is functionally in place, but compact semantic references should visibly surface role metadata, and modified frontend files should pass whitespace checks. That cleanup does not change the backend contract or the current product boundary.
+  </p>
+
+  <h2>Concrete Dataset Example</h2>
+  <p>
+    The current testing dataset named by the user is <code>D:/Data Bank/AI Tool Test Data/decision_intelligence_prompt_first_demo_clean_large.csv</code>. Its relevant columns are <code>month</code>, <code>region</code>, <code>channel</code>, <code>product_category</code>, <code>revenue</code>, <code>units_sold</code>, <code>marketing_spend</code>, <code>discount_pct</code>, <code>gross_margin_pct</code>, <code>return_rate_pct</code>, and <code>stockout_days</code>. This is a useful dataset for testing because it contains obvious objective candidates, controllable lever candidates, guardrail candidates, segmentation dimensions, and a temporal field.
+  </p>
+  <div class="example">
+    <div class="example-title">Explore-style prompt</div>
+    <p>
+      "What is gross_margin_pct by channel?"
+    </p>
+    <p>
+      The expected behavior is an Explore result. The system should treat <code>gross_margin_pct</code> as the metric and <code>channel</code> as the grouping dimension. The output should look like a grounded metric breakdown. This is what the user saw in the screenshot: a <code>SEMANTIC_METRIC (EXPLORE)</code> artifact showing channel values. That behavior is correct for a grouped metric question, but it is not meant to show the Phase 2 decision-frame improvements because the prompt is not a decision-frame prompt.
+    </p>
+  </div>
+  <div class="example">
+    <div class="example-title">Decision-style prompt</div>
+    <p>
+      "How should we grow revenue next quarter using marketing_spend and discount_pct as controllable levers, segmented by region and channel, while keeping gross_margin_pct above 30% and return_rate_pct below 4%?"
+    </p>
+    <p>
+      The expected behavior is a Decide result. The system should draft a workspace preview rather than just return a single grouped metric table. The objective should be tied to <code>revenue</code>. The levers should include <code>marketing_spend</code> and <code>discount_pct</code>. The guardrails should include <code>gross_margin_pct</code> and <code>return_rate_pct</code>. The segments should include <code>region</code> and <code>channel</code>. The time horizon should be interpreted as next quarter if the prompt parser can safely represent it; otherwise it should appear as a prompt-frame detail or a clarification area rather than silently disappearing.
+    </p>
+    <p>
+      The specific difference after Phase 2 is that the workspace preview and Decisions workspace should expose semantic role metadata and confidence around those mappings. Revenue should read as an objective candidate. Marketing spend and discount percent should read as lever candidates with controllability context. Gross margin percent and return rate percent should read as guardrail candidates. Region and channel should read as segment dimensions. If any term is weak, ambiguous, or unresolved, the UI should preserve it as a visible unresolved mapping with candidates and reasons instead of dropping it or making it look certain.
+    </p>
+  </div>
+
+  <h2>How To Explain The Feature To A Manager</h2>
+  <p>
+    At the business level, Decision Intelligence is a guided decision-framing layer over the company's data. It helps a user move from "I have a question" to "I have a structured decision frame that the team can inspect." It identifies the target outcome, the potential levers, the constraints that matter, the slices of the business worth comparing, and the evidence available in the data. It also tells the user when the frame is incomplete or when the requested analysis is outside the current product's capability.
+  </p>
+  <p>
+    The main value is not that the AI produces a magic answer. The value is that it reduces ambiguity in the early stage of decision work. Instead of leaving a prompt like "grow revenue without hurting margin" as a vague request, the system can translate it into objective revenue, lever discount percent or marketing spend, guardrail gross margin percent, and segment region or channel. That translation is visible, reviewable, and increasingly correctable as Phase 3 comes online.
+  </p>
+
+  <h2>How To Explain The Feature To A Developer</h2>
+  <p>
+    At the engineering level, Decision Intelligence is a contract-first workflow around semantic data interpretation. The frontend sends chat turns and actions with explicit state. The backend classifies mode, resolves semantic references, drafts or updates a workspace, evaluates readiness, returns artifacts, and declares capability boundaries. The frontend renders those artifacts and actions without inventing unsupported capability. The Decisions workspace is a durable rendering of the backend decision object, not a separate source of truth.
+  </p>
+  <p>
+    The system is built to be extended additively. New fields such as semantic roles, confidence, unresolved mappings, correction results, or ranked diagnostics can be added without breaking older frontend code, as long as existing endpoint names, artifact types, action ids, and compatibility fields are preserved. The current architecture expects frontend rendering to improve over time, but backend contracts remain the source of truth for readiness, allowed actions, unsupported capabilities, and observational boundaries.
+  </p>
+
+  <h2>Practical Review Checklist</h2>
+  <p>
+    When reviewing this feature, the most important question is not "did the assistant sound smart?" The better question is "did the system preserve the user's intent in structured, inspectable state, and did it stay inside its capability boundary?" A good Decide response should show the objective, levers, guardrails, segments, semantic confidence, unresolved mappings, readiness, allowed next actions, and unsupported capabilities where relevant. A good Explore response should answer the grounded analytic question without pretending it created a decision frame. A good Inquire response should stay concise and factual unless the prompt naturally escalates into exploration or decision framing.
+  </p>
+  <p>
+    The system should be considered healthy when a user can move from data question to exploration to decision workspace without losing context, and when every uncertain or unsupported claim is surfaced honestly. That is the product direction: decision intelligence as structured, inspectable support for human decision-making.
+  </p>
+</body>
+</html>

--- a/project_docs/INDEX.md
+++ b/project_docs/INDEX.md
@@ -18,7 +18,7 @@ After those files, read only the task-specific document listed below.
 
 | Need | Read |
 | --- | --- |
-| Execute the current implementation plan | `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md` |
+| Execute the current implementation plan | `project_docs/active/pdf_export_unification_plan.md` |
 | Review the council-derived roadmap | `project_docs/active/decision_intelligence/current/next_focus_execution_plan.md` |
 | Choose the next implementation slice | `project_docs/active/agent_council/outputs/application-next-focus-priorities/README.md` |
 | Inspect the full latest council recommendation | `project_docs/active/agent_council/outputs/application-next-focus-priorities/2026-05-01-council.json` |
@@ -33,7 +33,7 @@ Decision Intelligence V3 is active. V2 is closed as-is and lives as historical c
 
 Phase 4.5 AI Chat Decision Intelligence hardening is complete. The product now has real chat-to-decision continuity, scoped action behavior, truthful observational-analysis language, and verified frontend hardening.
 
-The next work is not broad frontend polish and not new simulation or optimization. Phase 1 reliability foundation and Phase 2 semantic role strengthening are complete as backend foundations. The active next implementation plan is Codex-owned Phase 3 correction and ranked observational evidence at `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md`. Frontend implementation remains Gemini-owned unless the user explicitly authorizes Codex frontend edits in the current session.
+The next work is not broad frontend polish and not new simulation or optimization. Phase 1 reliability foundation is complete. Phase 2 semantic metadata plumbing is implemented, but May 14 PDF review showed the active prompt-first decision frame still drops or misclassifies key semantic roles. Before Phase 2.5 continues, the active next implementation plan is app-wide PDF export unification at `project_docs/active/pdf_export_unification_plan.md`, because exports must accurately match visible app content for reliable review. Phase 2.5 semantic frame completion is next after PDF export unification. Phase 3 correction and ranked observational evidence is deferred until Phase 2.5 is complete. Frontend implementation remains Gemini-owned unless the user explicitly authorizes Codex frontend edits in the current session; the PDF export branch prompt explicitly authorizes Codex to work on the export UI and frontend export code.
 
 ## Folder Map
 

--- a/project_docs/INDEX.md
+++ b/project_docs/INDEX.md
@@ -18,7 +18,7 @@ After those files, read only the task-specific document listed below.
 
 | Need | Read |
 | --- | --- |
-| Execute the current implementation plan | `project_docs/active/decision_intelligence/current/phase_2_semantic_role_strengthening_plan.md` |
+| Execute the current implementation plan | `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md` |
 | Review the council-derived roadmap | `project_docs/active/decision_intelligence/current/next_focus_execution_plan.md` |
 | Choose the next implementation slice | `project_docs/active/agent_council/outputs/application-next-focus-priorities/README.md` |
 | Inspect the full latest council recommendation | `project_docs/active/agent_council/outputs/application-next-focus-priorities/2026-05-01-council.json` |
@@ -33,7 +33,7 @@ Decision Intelligence V3 is active. V2 is closed as-is and lives as historical c
 
 Phase 4.5 AI Chat Decision Intelligence hardening is complete. The product now has real chat-to-decision continuity, scoped action behavior, truthful observational-analysis language, and verified frontend hardening.
 
-The next work is not broad frontend polish and not new simulation or optimization. Phase 1 reliability foundation is complete. The active next work is Codex-owned Phase 2 semantic role strengthening: additive decision-aware semantic roles, confidence, aliases, polarity, controllability, and unresolved mapping details.
+The next work is not broad frontend polish and not new simulation or optimization. Phase 1 reliability foundation and Phase 2 semantic role strengthening are complete as backend foundations. The active next implementation plan is Codex-owned Phase 3 correction and ranked observational evidence at `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md`. Frontend implementation remains Gemini-owned unless the user explicitly authorizes Codex frontend edits in the current session.
 
 ## Folder Map
 

--- a/project_docs/active/README.md
+++ b/project_docs/active/README.md
@@ -12,9 +12,11 @@ Its job is to stop agents from scanning old plans, completed handoffs, and archi
 | 2 | `project_docs/active/rules/CODEX_FRONTEND_GUARDRAIL_READ_FIRST.md` | Ownership boundary: Codex does backend/contracts/docs; Gemini owns frontend unless explicitly reauthorized. |
 | 3 | `project_docs/active/agent_council/outputs/application-next-focus-priorities/README.md` | Current next-focus decision after Phase 4.5 hardening. |
 | 4 | `project_docs/active/agent_council/outputs/application-next-focus-priorities/2026-05-01-council.json` | Detailed ranked recommendations for the next work. |
-| 5 | `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md` | Active implementation plan. |
-| 6 | `project_docs/active/decision_intelligence/current/next_focus_execution_plan.md` | Council-derived roadmap and later-phase sequencing. |
-| 7 | `project_docs/active/contracts/decision_objects.md` | Current backend/frontend decision object contract reference. |
+| 5 | `project_docs/active/pdf_export_unification_plan.md` | Active implementation plan. |
+| 6 | `project_docs/active/decision_intelligence/current/phase_2_5_semantic_frame_completion_plan.md` | Next plan after PDF export unification. |
+| 7 | `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md` | Deferred next plan after Phase 2.5 is complete. |
+| 8 | `project_docs/active/decision_intelligence/current/next_focus_execution_plan.md` | Council-derived roadmap and later-phase sequencing. |
+| 9 | `project_docs/active/contracts/decision_objects.md` | Current backend/frontend decision object contract reference. |
 
 Do not start by reading every file in `project_docs/active/decision_intelligence/`. That folder now has a README plus `current/` and `completed/` subfolders. Read the README first and open only the specific file needed.
 
@@ -22,7 +24,7 @@ Do not start by reading every file in `project_docs/active/decision_intelligence
 
 Decision Intelligence V3 is the active product line. Phase 4.5 AI Chat hardening is complete. The app has a real backend chat contract, grounded `ask`, `explore`, and `decide` modes, real action handling, chat-to-Decisions continuity, truthful observational-analysis language, and improved artifact rendering.
 
-Phase 1 reliability foundation is complete. Phase 2 semantic role strengthening is complete as the backend semantic foundation, and Gemini frontend integration is functionally in place with minor Gemini-owned cleanup still tracked from review. The active next Codex slice is Phase 3 correction and ranked observational evidence. Codex must still avoid frontend edits unless explicitly authorized.
+Phase 1 reliability foundation is complete. Phase 2 semantic metadata plumbing is implemented, and Gemini frontend integration is functionally in place, but May 14 PDF review showed the active prompt-first decision frame still drops or misclassifies key semantic roles. Before Phase 2.5 continues, the active next Codex slice is app-wide PDF export unification so exported results accurately match visible app content. Phase 2.5 semantic frame completion is next after PDF export unification. Phase 3 correction and ranked observational evidence is deferred until Phase 2.5 is complete.
 
 ## Documentation Areas
 
@@ -38,9 +40,9 @@ Phase 1 reliability foundation is complete. Phase 2 semantic role strengthening 
 
 ## Current Next Work
 
-The next implementation slice should be Codex-owned backend support for Phase 3 correction and ranked observational evidence, using `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md`. Gemini remains responsible for any frontend cleanup or Phase 3 frontend rendering after a scoped handoff.
+The next implementation slice should be Codex-owned app-wide PDF export unification, using `project_docs/active/pdf_export_unification_plan.md`. This branch is explicitly about frontend export code and export UI; the branch prompt authorizes Codex to work on those PDF export surfaces. Broader unrelated frontend cleanup still belongs to Gemini unless the user explicitly authorizes it.
 
-Good first files for that slice are `backend/decision_engine/chat_service.py`, `backend/services/decision_workspace_service.py`, `backend/services/decision_support.py`, `tests/test_decision_reliability_benchmark.py`, `tests/test_decision_workspace_service.py`, any new Phase 3 correction or ranked-evidence tests, and `project_docs/active/contracts/decision_objects.md`.
+Good first files for that slice are `frontend/frontend/src/utils/pdfReportExport.js`, `frontend/frontend/src/utils/decisionPdfExport.js`, `frontend/frontend/src/features/charts/ChartToolbar.jsx`, `frontend/frontend/src/components/insights/DataStoryPanel.jsx`, `frontend/frontend/src/components/data_management/FileExport.jsx`, `frontend/frontend/src/features/workflow/AIReporter.jsx`, `frontend/frontend/src/features/ai/AIShell.jsx`, `frontend/frontend/src/features/business/decision/DecisionWorkspaceView.jsx`, and the related CSS files.
 
 ## Do Not Scan By Default
 

--- a/project_docs/active/README.md
+++ b/project_docs/active/README.md
@@ -12,7 +12,7 @@ Its job is to stop agents from scanning old plans, completed handoffs, and archi
 | 2 | `project_docs/active/rules/CODEX_FRONTEND_GUARDRAIL_READ_FIRST.md` | Ownership boundary: Codex does backend/contracts/docs; Gemini owns frontend unless explicitly reauthorized. |
 | 3 | `project_docs/active/agent_council/outputs/application-next-focus-priorities/README.md` | Current next-focus decision after Phase 4.5 hardening. |
 | 4 | `project_docs/active/agent_council/outputs/application-next-focus-priorities/2026-05-01-council.json` | Detailed ranked recommendations for the next work. |
-| 5 | `project_docs/active/decision_intelligence/current/phase_2_semantic_role_strengthening_plan.md` | Active implementation plan. |
+| 5 | `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md` | Active implementation plan. |
 | 6 | `project_docs/active/decision_intelligence/current/next_focus_execution_plan.md` | Council-derived roadmap and later-phase sequencing. |
 | 7 | `project_docs/active/contracts/decision_objects.md` | Current backend/frontend decision object contract reference. |
 
@@ -22,7 +22,7 @@ Do not start by reading every file in `project_docs/active/decision_intelligence
 
 Decision Intelligence V3 is the active product line. Phase 4.5 AI Chat hardening is complete. The app has a real backend chat contract, grounded `ask`, `explore`, and `decide` modes, real action handling, chat-to-Decisions continuity, truthful observational-analysis language, and improved artifact rendering.
 
-Phase 1 reliability foundation is complete. The active next priority is Phase 2 semantic role strengthening, not broad feature expansion. The next Codex-owned slice should add decision-aware semantic roles, confidence, aliases, polarity, controllability, and unresolved mapping details while preserving existing contracts. Gemini frontend work should wait until backend semantic fields and contracts stabilize.
+Phase 1 reliability foundation is complete. Phase 2 semantic role strengthening is complete as the backend semantic foundation, and Gemini frontend integration is functionally in place with minor Gemini-owned cleanup still tracked from review. The active next Codex slice is Phase 3 correction and ranked observational evidence. Codex must still avoid frontend edits unless explicitly authorized.
 
 ## Documentation Areas
 
@@ -38,13 +38,9 @@ Phase 1 reliability foundation is complete. The active next priority is Phase 2 
 
 ## Current Next Work
 
-The next implementation slice should be:
+The next implementation slice should be Codex-owned backend support for Phase 3 correction and ranked observational evidence, using `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md`. Gemini remains responsible for any frontend cleanup or Phase 3 frontend rendering after a scoped handoff.
 
-Implement Phase 2 semantic role strengthening. Add additive backend semantic metadata that helps decision framing distinguish objective metrics, controllable levers, guardrails, segment dimensions, temporal fields, weak mappings, and ambiguity without pretending low-confidence matches are certain.
-
-The active plan for that work is `project_docs/active/decision_intelligence/current/phase_2_semantic_role_strengthening_plan.md`.
-
-Good first files for that slice are `backend/services/semantic_model.py`, `backend/routes/semantic_model.py`, `backend/decision_engine/chat_service.py`, `backend/services/decision_workspace_service.py`, `tests/test_decision_reliability_benchmark.py`, `tests/test_decision_workspace_service.py`, and `project_docs/active/contracts/decision_objects.md`.
+Good first files for that slice are `backend/decision_engine/chat_service.py`, `backend/services/decision_workspace_service.py`, `backend/services/decision_support.py`, `tests/test_decision_reliability_benchmark.py`, `tests/test_decision_workspace_service.py`, any new Phase 3 correction or ranked-evidence tests, and `project_docs/active/contracts/decision_objects.md`.
 
 ## Do Not Scan By Default
 

--- a/project_docs/active/contracts/decision_objects.md
+++ b/project_docs/active/contracts/decision_objects.md
@@ -56,6 +56,39 @@ Legacy compatibility note: existing fields such as `can_run_simulation` and `blo
 | `row_count` | `integer` | Yes | Row count for the resolved dataset |
 | `column_count` | `integer` | Yes | Column count for the resolved dataset |
 
+### Decision Semantics For Metrics
+
+Additive role metadata attached to semantic model metrics and echoed on `Metric Reference` objects when available. Older semantic models remain valid; the backend finalizer can infer conservative defaults from names, fields, format hints, aggregation, and existing metadata.
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `objective_candidate` | `boolean` | Yes | Whether this metric is plausibly a business objective or success measure |
+| `lever_candidate` | `boolean` | Yes | Whether this metric is plausibly a controllable lever |
+| `guardrail_candidate` | `boolean` | Yes | Whether this metric is plausibly a threshold, constraint, or guardrail |
+| `polarity` | `string` | Yes | `increase_is_good`, `decrease_is_good`, `context_dependent`, or `unknown` |
+| `controllability` | `string` | Yes | `controllable`, `outcome`, or `unknown` in the current implementation |
+| `aliases` | `string[]` | Yes | Names, labels, fields, and normalized business aliases used as matching evidence |
+| `business_terms` | `string[]` | Yes | Matched business-role keywords such as `revenue`, `discount`, `margin`, or `risk` |
+| `confidence` | `number` | Yes | Conservative `0.0` to `1.0` confidence for the role metadata, not a model-quality guarantee |
+| `confidence_reason` | `string` | Yes | Short explanation of the evidence used for the confidence score |
+| `unresolved_reasons` | `string[]` | Yes | Reasons the role should be reviewed, including low evidence or multiple plausible roles |
+
+### Decision Semantics For Dimensions
+
+Additive role metadata attached to semantic model dimensions and echoed on `Dimension Reference` objects when available.
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `segment_candidate` | `boolean` | Yes | Whether this dimension is suitable for segmentation or slicing |
+| `comparison_candidate` | `boolean` | Yes | Whether this dimension is suitable for comparison |
+| `temporal_candidate` | `boolean` | Yes | Whether this dimension is temporal |
+| `grain` | `string \| null` | No | `day`, `week`, `month`, `quarter`, `year`, `observed_value`, or `null` when not temporal |
+| `aliases` | `string[]` | Yes | Names, labels, fields, and normalized business aliases used as matching evidence |
+| `business_terms` | `string[]` | Yes | Matched temporal or business terms |
+| `confidence` | `number` | Yes | Conservative `0.0` to `1.0` confidence for the dimension role metadata |
+| `confidence_reason` | `string` | Yes | Short explanation of the evidence used for the confidence score |
+| `unresolved_reasons` | `string[]` | Yes | Reasons the role should be reviewed |
+
 ### Metric Reference
 
 | Field | Type | Required | Notes |
@@ -66,6 +99,11 @@ Legacy compatibility note: existing fields such as `can_run_simulation` and `blo
 | `field` | `string \| null` | No | Backing field when applicable |
 | `default_aggregation` | `string \| null` | No | `sum`, `mean`, `count`, etc. |
 | `format_hint` | `string \| null` | No | `number`, `currency`, `percentage`, `date`, or `null` |
+| `decision_semantics` | `Decision Semantics For Metrics \| null` | No | Additive role metadata when the semantic model has been finalized by Phase 2 backend code |
+| `semantic_binding_confidence` | `number \| null` | No | Prompt-specific binding confidence when the ref was selected from prompt text |
+| `semantic_binding_reason` | `string \| null` | No | Prompt-specific binding reason |
+| `semantic_role_source` | `string \| null` | No | `decision_semantics`, `lexical_match`, `raw_field`, or `unresolved` |
+| `semantic_role_warnings` | `string[]` | No | Prompt-specific warnings such as role mismatch, ambiguity, or low-confidence evidence |
 
 ### Dimension Reference
 
@@ -77,6 +115,23 @@ Legacy compatibility note: existing fields such as `can_run_simulation` and `blo
 | `field` | `string` | Yes | Backing dataset field |
 | `semantic_kind` | `string \| null` | No | `categorical`, `temporal`, etc. |
 | `data_type` | `string \| null` | No | `string`, `datetime`, `number`, etc. |
+| `decision_semantics` | `Decision Semantics For Dimensions \| null` | No | Additive role metadata when the semantic model has been finalized by Phase 2 backend code |
+| `semantic_binding_confidence` | `number \| null` | No | Prompt-specific binding confidence when the ref was selected from prompt text |
+| `semantic_binding_reason` | `string \| null` | No | Prompt-specific binding reason |
+| `semantic_role_source` | `string \| null` | No | `decision_semantics`, `lexical_match`, `raw_field`, or `unresolved` |
+| `semantic_role_warnings` | `string[]` | No | Prompt-specific warnings such as role mismatch, ambiguity, or low-confidence evidence |
+
+### Prompt Semantic Binding Trace
+
+Prompt-first decision workspace drafting now preserves semantic binding traceability. The fields are additive and may appear on `decision_scope.objective`, lever or constraint `binding` objects, and prompt match refs under `decision_workspace.drafting.prompt_matches`.
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `semantic_binding_confidence` | `number \| null` | No | Prompt-specific confidence for the selected semantic object; unresolved bindings use `0.0` or `null` depending on whether an attempted binding existed |
+| `semantic_binding_reason` | `string \| null` | No | Human-readable evidence summary |
+| `semantic_role_source` | `string \| null` | No | `decision_semantics`, `lexical_match`, `raw_field`, or `unresolved` |
+| `semantic_role_warnings` | `string[]` | No | Warnings when metadata is weak, ambiguous, role-conflicting, or raw-field-only |
+| `unresolved_mappings` | `object[]` | No | Present under `drafting.prompt_matches`; each item includes `mapping_type`, `status`, `reason`, `candidate_labels`, and optional `confidence` |
 
 ### Time Context
 

--- a/project_docs/active/decision_intelligence/README.md
+++ b/project_docs/active/decision_intelligence/README.md
@@ -10,13 +10,13 @@ This folder is organized so current work and completed records are no longer mix
 
 The current truth lives in `project_docs/active/status/decision_intelligence_execution_status.md`, not in older phase plans in this folder.
 
-Phase 4.5 hardening and Phase 1 reliability foundation are complete. The next work is defined in `current/phase_2_semantic_role_strengthening_plan.md`: additive decision-aware semantic roles, confidence, aliases, polarity, controllability, and unresolved mapping details.
+Phase 4.5 hardening, Phase 1 reliability foundation, and Phase 2 semantic role strengthening are complete as backend foundations. The next work is defined in `current/phase_3_correction_and_observational_evidence_plan.md`: deterministic decision-frame corrections and ranked observational evidence.
 
 ## Read These By Task
 
 | Task | Read |
 | --- | --- |
-| Resume current Decision Intelligence work | `project_docs/active/status/decision_intelligence_execution_status.md`, then `current/phase_2_semantic_role_strengthening_plan.md` |
+| Resume current Decision Intelligence work | `project_docs/active/status/decision_intelligence_execution_status.md`, then `current/phase_3_correction_and_observational_evidence_plan.md` |
 | Review the council-derived roadmap | `current/next_focus_execution_plan.md` |
 | Review completed prompt-first intake behavior | `completed/phase_3_5_decision_intake_rework.md` |
 | Work on the completed chat backend contract | `completed/decision_intelligence_v3_phase_4_backend_checkpoint.md`, `completed/decision_intelligence_v3_phase_4_chat_engine_execution_plan.md` |
@@ -35,6 +35,8 @@ The files below are useful records but should not be scanned by default:
 | `completed/slice_2_5_gemini_frontend_handoff.md` | Completed Slice 2.5 frontend handoff record. |
 | `completed/slice_3_real_action_system_gemini_frontend_handoff.md` | Completed Slice 3 frontend handoff record. |
 | `completed/phase_1_reliability_fields_gemini_handoff.md` | Completed Phase 1 reliability frontend handoff and review record. |
+| `completed/phase_2_semantic_role_strengthening_plan.md` | Completed Phase 2 backend plan and acceptance record. |
+| `completed/phase_2_semantic_role_strengthening_gemini_handoff.md` | Completed Phase 2 semantic frontend handoff record. |
 | `completed/decision_intelligence_v3_phase_4_execution_checklist.md` | Historical checklist. Some unchecked items may be stale; active status wins. |
 
 ## Ownership Reminder

--- a/project_docs/active/decision_intelligence/README.md
+++ b/project_docs/active/decision_intelligence/README.md
@@ -10,13 +10,15 @@ This folder is organized so current work and completed records are no longer mix
 
 The current truth lives in `project_docs/active/status/decision_intelligence_execution_status.md`, not in older phase plans in this folder.
 
-Phase 4.5 hardening, Phase 1 reliability foundation, and Phase 2 semantic role strengthening are complete as backend foundations. The next work is defined in `current/phase_3_correction_and_observational_evidence_plan.md`: deterministic decision-frame corrections and ranked observational evidence.
+Phase 4.5 hardening and Phase 1 reliability foundation are complete. Phase 2 semantic metadata plumbing is implemented, but May 14 PDF review showed the active prompt-first decision frame still drops or misclassifies key semantic roles. Before Phase 2.5 continues, the active next project work is app-wide PDF export unification at `project_docs/active/pdf_export_unification_plan.md`, because exports must accurately match visible app content for reliable review. After the PDF work, return to `current/phase_2_5_semantic_frame_completion_plan.md` to finish prompt-first semantic frame extraction. Phase 3 correction and ranked observational evidence is deferred until Phase 2.5 is complete.
 
 ## Read These By Task
 
 | Task | Read |
 | --- | --- |
-| Resume current Decision Intelligence work | `project_docs/active/status/decision_intelligence_execution_status.md`, then `current/phase_3_correction_and_observational_evidence_plan.md` |
+| Resume current project work | `project_docs/active/status/decision_intelligence_execution_status.md`, then `project_docs/active/pdf_export_unification_plan.md` |
+| Resume Phase 2.5 after PDF export work | `project_docs/active/status/decision_intelligence_execution_status.md`, then `current/phase_2_5_semantic_frame_completion_plan.md` |
+| Review the deferred Phase 3 plan | `current/phase_3_correction_and_observational_evidence_plan.md` |
 | Review the council-derived roadmap | `current/next_focus_execution_plan.md` |
 | Review completed prompt-first intake behavior | `completed/phase_3_5_decision_intake_rework.md` |
 | Work on the completed chat backend contract | `completed/decision_intelligence_v3_phase_4_backend_checkpoint.md`, `completed/decision_intelligence_v3_phase_4_chat_engine_execution_plan.md` |

--- a/project_docs/active/decision_intelligence/completed/phase_1_reliability_fields_gemini_handoff.md
+++ b/project_docs/active/decision_intelligence/completed/phase_1_reliability_fields_gemini_handoff.md
@@ -1,4 +1,4 @@
-> COMPLETED REFERENCE ONLY: This file records the completed Phase 1 reliability frontend handoff and review loop. It is not part of the default active scan path. Current work is routed through `project_docs/active/status/decision_intelligence_execution_status.md` and `project_docs/active/decision_intelligence/current/phase_2_semantic_role_strengthening_plan.md`.
+> COMPLETED REFERENCE ONLY: This file records the completed Phase 1 reliability frontend handoff and review loop. It is not part of the default active scan path. Current work is routed through `project_docs/active/status/decision_intelligence_execution_status.md` and the current plan under `project_docs/active/decision_intelligence/current/`.
 
 # Phase 1 Reliability Fields Gemini Handoff
 

--- a/project_docs/active/decision_intelligence/completed/phase_2_semantic_role_strengthening_gemini_handoff.md
+++ b/project_docs/active/decision_intelligence/completed/phase_2_semantic_role_strengthening_gemini_handoff.md
@@ -1,0 +1,39 @@
+> COMPLETED REFERENCE ONLY: This file records the Phase 2 Gemini frontend handoff. It is not the active implementation plan.
+
+# Phase 2 Semantic Role Strengthening Gemini Handoff
+
+## Backend Truth
+
+Codex completed the backend-first Phase 2 semantic role strengthening slice on May 10, 2026.
+
+Semantic model metrics now include additive `decision_semantics` with objective, lever, guardrail, polarity, controllability, aliases, business terms, confidence, confidence reason, and unresolved review reasons.
+
+Semantic model dimensions now include additive `decision_semantics` with segment, comparison, temporal, grain, aliases, business terms, confidence, confidence reason, and unresolved review reasons.
+
+Decision Workspace prompt-first drafting now carries prompt-level binding trace fields on objective objects, lever bindings, constraint bindings, and prompt-match refs: `semantic_binding_confidence`, `semantic_binding_reason`, `semantic_role_source`, and `semantic_role_warnings`. `decision_workspace.drafting.prompt_matches.unresolved_mappings` exposes ambiguous or unsafe matches instead of hiding them.
+
+The backend remains observational only. Do not add simulation, optimization, autonomous decisioning, final recommendation language, or frontend assumptions that make low-confidence semantic matches look certain.
+
+## Frontend Scope
+
+Gemini should inspect frontend rendering paths that already display Decision Workspace objective, levers, guardrails, prompt matches, diagnostics, and workspace preview artifacts. The likely files are under `frontend/frontend/src/`, especially AI Chat artifact rendering and Decisions workspace rendering. Codex did not edit frontend files in this slice.
+
+The UI should render the new fields only where they improve trust and inspectability. Prefer compact confidence, role, and warning details near the semantic object already being displayed. Treat low-confidence or ambiguous mapping details as review hints, not errors and not final recommendations.
+
+Acceptance behavior: existing frontend flows must continue to work with older semantic models that lack `decision_semantics`; new metadata should be optional and additive. The UI should make unresolved or ambiguous semantic mappings visible when present, and it must preserve the observational-analysis boundary already implemented in Phase 1.
+
+## Verification
+
+Codex verified the backend with the bundled Python runtime:
+
+`tests.test_semantic_role_strengthening` passed.
+
+`tests.test_decision_workspace_service` passed.
+
+`tests.test_decision_reliability_benchmark` passed.
+
+Plain `python -m unittest` under `C:\Program Files\Python311\python.exe` is currently blocked by local package visibility for pandas/dateutil. `tests.test_decision_chat_service` remains blocked in this environment by Flask dependency visibility.
+
+## Gemini Prompt
+
+Review and implement frontend support for the Phase 2 semantic role strengthening backend fields. Do not change backend files. Inspect the AI Chat artifact rendering and Decisions workspace rendering under `frontend/frontend/src/`. The backend now adds optional `decision_semantics` to metric and dimension refs, plus prompt binding trace fields `semantic_binding_confidence`, `semantic_binding_reason`, `semantic_role_source`, `semantic_role_warnings`, and `decision_workspace.drafting.prompt_matches.unresolved_mappings`. Render these fields compactly where they help users understand objective, lever, guardrail, segment, temporal, weak-match, and ambiguity details. Preserve older semantic models that do not include the fields. Preserve the observational-analysis-only boundary and do not introduce simulation, optimization, autonomous decisioning, or final recommendation language. Run the frontend build and update `project_docs/active/status/decision_intelligence_execution_status.md` truthfully with what changed and what passed.

--- a/project_docs/active/decision_intelligence/completed/phase_2_semantic_role_strengthening_plan.md
+++ b/project_docs/active/decision_intelligence/completed/phase_2_semantic_role_strengthening_plan.md
@@ -1,20 +1,24 @@
+> COMPLETED REFERENCE ONLY: This file is not part of the default active scan path. Current work should start from `project_docs/active/status/decision_intelligence_execution_status.md` and the active plan under `project_docs/active/decision_intelligence/current/`.
+
 # Phase 2 Semantic Role Strengthening Plan
 
 ## Purpose
 
-This is the active next implementation plan after Phase 1 Decision Intelligence reliability foundation completion.
+This was the active implementation plan after Phase 1 Decision Intelligence reliability foundation completion. It is now completed reference material.
 
 Phase 1 made decision framing measurable and added backend-owned readiness and capability boundaries. Phase 2 should improve the semantic grounding that feeds those decision frames, so the system can distinguish objective metrics, controllable levers, guardrails, segment dimensions, temporal fields, ambiguous mappings, and unsafe weak matches with explicit confidence.
 
 ## Current Status
 
-Status: ready to start.
+Status: backend implementation complete; frontend rendering handoff completed and moved to completed reference records.
 
 Owner: Codex for backend, contracts, tests, and documentation.
 
 Frontend ownership remains Gemini. Do not change frontend files unless the user explicitly authorizes Codex frontend edits in the current session.
 
 Primary council recommendation: `rec-semantic-model-role-strengthening`.
+
+May 10, 2026 update: Codex implemented the backend slice. Semantic model finalization now emits additive `decision_semantics` for metrics and dimensions. Decision Workspace prompt-first drafting now carries prompt-specific semantic binding confidence, reasons, source, warnings, and unresolved mapping details. The decision object contract and active execution status have been updated. Gemini frontend rendering is not implemented in this Codex slice.
 
 ## Non-Goals
 
@@ -132,4 +136,4 @@ If `tests.test_decision_chat_service` is still blocked by local Flask visibility
 
 ## Start Prompt
 
-Implement Phase 2 from `project_docs/active/decision_intelligence/current/phase_2_semantic_role_strengthening_plan.md`. Keep it backend-first. Add additive decision-aware semantic role metadata, conservative confidence, unresolved mapping details, and tests that protect against semantic false confidence. Update the decision object contract and active status docs truthfully. Do not edit frontend files unless explicitly authorized.
+Historical start prompt: implement Phase 2 from this completed reference. Keep it backend-first. Add additive decision-aware semantic role metadata, conservative confidence, unresolved mapping details, and tests that protect against semantic false confidence. Update the decision object contract and active status docs truthfully. Do not edit frontend files unless explicitly authorized.

--- a/project_docs/active/decision_intelligence/current/next_focus_execution_plan.md
+++ b/project_docs/active/decision_intelligence/current/next_focus_execution_plan.md
@@ -13,8 +13,8 @@ The council recommends measurable Decision Intelligence reliability before broad
 The strongest next path is:
 
 1. Build a reliability benchmark and capability/readiness boundary. Completed.
-2. Strengthen semantic role detection and confidence. Active next.
-3. Add correction and richer observational evidence.
+2. Strengthen semantic role detection and confidence. Completed.
+3. Add correction and richer observational evidence. Active next.
 4. Align active dataset truth across surfaces.
 5. Add ML readiness diagnostics.
 6. Design future simulation and trade-off contracts without implementing simulation.
@@ -36,8 +36,8 @@ Do not treat ranked observational evidence as ranked recommendations.
 | Phase | Owner | Status | Source Recommendation | Objective |
 | --- | --- | --- | --- | --- |
 | 1 | Codex and Gemini | Complete | `rec-decision-reliability-foundation` | Add prompt benchmark fixtures, grading checks, additive capability/readiness fields, and frontend rendering of reliability truth. |
-| 2 | Codex | Active next | `rec-semantic-model-role-strengthening` | Add decision-aware semantic roles, confidence, aliases, polarity, controllability, and unresolved mapping details. |
-| 3 | Codex first, Gemini after backend contract stabilizes | Later | `rec-decision-frame-correction-loop`, `rec-ranked-observational-evidence` | Add frame correction actions and richer ranked observational evidence. |
+| 2 | Codex and Gemini | Complete, with minor Gemini cleanup pending | `rec-semantic-model-role-strengthening` | Add decision-aware semantic roles, confidence, aliases, polarity, controllability, and unresolved mapping details. |
+| 3 | Codex first, Gemini after backend contract stabilizes | Active next | `rec-decision-frame-correction-loop`, `rec-ranked-observational-evidence` | Add frame correction actions and richer ranked observational evidence. |
 | 4 | Codex planning, Gemini frontend implementation | Later | `rec-canonical-active-dataset-contract` | Define and implement one active dataset source of truth across AI chat, Decisions, charts, dashboards, and workflows. |
 | 5 | Codex | Deferred | `rec-decision-context-ml-readiness` | Add ML readiness diagnostics without producing predictions or recommendations. |
 | 6 | Codex | Deferred design only | `rec-future-simulation-contract-design` | Design future simulation/trade-off contracts without runtime simulation or frontend claims. |
@@ -78,7 +78,7 @@ Unsupported simulation, optimization, autonomous decisioning, and final recommen
 
 ## Phase 2: Semantic Role Strengthening
 
-Phase 2 is the active next implementation slice. The detailed plan lives at `project_docs/active/decision_intelligence/current/phase_2_semantic_role_strengthening_plan.md`.
+Phase 2 is complete as the semantic-role foundation for later work. The detailed completed plan remains at `project_docs/active/decision_intelligence/completed/phase_2_semantic_role_strengthening_plan.md`.
 
 The benchmark should become the measuring stick for semantic improvements.
 
@@ -97,6 +97,8 @@ Ambiguous mappings can trigger clarification or review instead of silent weak se
 Semantic collision, no-safe-match, missing metric, guardrail-only, and segment-only tests pass.
 
 ## Phase 3: Correction And Ranked Observational Evidence
+
+Phase 3 is the active next implementation slice. The detailed plan lives at `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md`.
 
 Phase 3 should add trust controls after semantic roles and readiness fields are stable.
 
@@ -175,5 +177,5 @@ The council left four useful choices open.
 
 ## Current Slice Prompt For Codex
 
-Implement Phase 2 from `project_docs/active/decision_intelligence/current/phase_2_semantic_role_strengthening_plan.md`. Keep it backend-first. Add additive decision-aware semantic role metadata, conservative confidence, unresolved mapping details, and tests that protect against semantic false confidence. Update the decision object contract and active status docs truthfully. Do not edit frontend files unless explicitly authorized.
+Implement Phase 3 from `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md`. Keep it backend-first. Add deterministic decision-frame correction actions and ranked observational evidence, preserving existing endpoint names, action IDs, artifact types, readiness fields, and the observational-analysis-only boundary. Use Phase 2 semantic role confidence and unresolved mapping trace where it helps correction and evidence ranking. Update backend tests, `project_docs/active/contracts/decision_objects.md`, and active status docs truthfully. Do not edit frontend files unless explicitly authorized.
 

--- a/project_docs/active/decision_intelligence/current/next_focus_execution_plan.md
+++ b/project_docs/active/decision_intelligence/current/next_focus_execution_plan.md
@@ -78,7 +78,7 @@ Unsupported simulation, optimization, autonomous decisioning, and final recommen
 
 ## Phase 2: Semantic Role Strengthening
 
-Phase 2 is complete as the semantic-role foundation for later work. The detailed completed plan remains at `project_docs/active/decision_intelligence/completed/phase_2_semantic_role_strengthening_plan.md`.
+Phase 2 implemented the semantic-role metadata foundation for later work. The detailed completed plan remains at `project_docs/active/decision_intelligence/completed/phase_2_semantic_role_strengthening_plan.md`.
 
 The benchmark should become the measuring stick for semantic improvements.
 
@@ -96,9 +96,53 @@ Ambiguous mappings can trigger clarification or review instead of silent weak se
 
 Semantic collision, no-safe-match, missing metric, guardrail-only, and segment-only tests pass.
 
+## App-Wide PDF Export Unification
+
+App-wide PDF export unification is the active next implementation slice. The detailed plan lives at `project_docs/active/pdf_export_unification_plan.md`.
+
+This work was moved ahead of Phase 2.5 after the first Decision Intelligence PDF export proved useful for debugging but too inaccurate and clunky for product review. The export must accurately match the visible decision, chat, chart, story, or report content being exported. Normal PDFs should be compact, polished, and same-as-window where practical, not raw JSON debug dumps.
+
+Exit criteria:
+
+One shared export system or documented adapter layer is used across current PDF export entry points.
+
+AI Chat relevant artifacts export as the visible card or inspector content.
+
+Decisions workspace export matches the visible workspace and visible analysis content.
+
+Charts, Data Story, workflow reports, and file export keep working with consistent styling.
+
+Normal PDF output does not dump raw JSON by default.
+
+`npm --prefix frontend\frontend run build` and `git diff --check` pass for touched files.
+
+## Phase 2.5: Semantic Frame Completion
+
+Phase 2.5 is the next implementation slice after PDF export unification. The detailed plan lives at `project_docs/active/decision_intelligence/current/phase_2_5_semantic_frame_completion_plan.md`.
+
+May 14 PDF review showed that Phase 2 metadata exists, but the active prompt-first decision frame is still not reliable enough. The exact test prompt routed to `decide` and exposed semantic metadata, but `gross_margin_pct above 30%` did not become an active guardrail, `return_rate_pct below 4%` lost its threshold value, `region and channel` were inconsistent as segments, and `channel mix` was incorrectly introduced as a lever.
+
+Phase 2.5 should fix prompt-first role extraction before the correction loop and ranked observational evidence work begins. This phase should stay backend-first and should not become broad frontend polish.
+
+Exit criteria:
+
+The active frame for the May 14 prompt has objective `revenue`.
+
+The active levers are `marketing_spend` and `discount_pct`.
+
+The active segment dimensions include both `region` and `channel`.
+
+The active guardrails include `gross_margin_pct above 30%` and `return_rate_pct below 4%`.
+
+Guardrail thresholds are non-null and directionally correct.
+
+`channel mix` is not added as a lever unless the prompt explicitly asks to change or shift channel mix.
+
+Phase 2 semantic confidence, reason, source, warnings, and unresolved or omission details remain truthful.
+
 ## Phase 3: Correction And Ranked Observational Evidence
 
-Phase 3 is the active next implementation slice. The detailed plan lives at `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md`.
+Phase 3 is deferred until Phase 2.5 is complete. The detailed plan lives at `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md`.
 
 Phase 3 should add trust controls after semantic roles and readiness fields are stable.
 
@@ -177,5 +221,5 @@ The council left four useful choices open.
 
 ## Current Slice Prompt For Codex
 
-Implement Phase 3 from `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md`. Keep it backend-first. Add deterministic decision-frame correction actions and ranked observational evidence, preserving existing endpoint names, action IDs, artifact types, readiness fields, and the observational-analysis-only boundary. Use Phase 2 semantic role confidence and unresolved mapping trace where it helps correction and evidence ranking. Update backend tests, `project_docs/active/contracts/decision_objects.md`, and active status docs truthfully. Do not edit frontend files unless explicitly authorized.
+Implement app-wide PDF export unification from `project_docs/active/pdf_export_unification_plan.md`. The export to PDF must accurately match the visible decision, chat, chart, story, or report content being exported. Build one shared, polished export system or a clearly documented adapter layer used by all current PDF export entry points. Normal PDFs should not dump raw JSON by default; they should be compact, visually aligned with the app, accessible, and smooth. Preserve current export entry points for charts, Data Story, AI Chat relevant artifacts, Decisions workspace, workflow reports, and file export where applicable. Verify with `npm --prefix frontend\frontend run build` and `git diff --check` on touched files. Do not implement Phase 2.5 semantic frame fixes in this branch.
 

--- a/project_docs/active/decision_intelligence/current/phase_2_5_semantic_frame_completion_plan.md
+++ b/project_docs/active/decision_intelligence/current/phase_2_5_semantic_frame_completion_plan.md
@@ -1,0 +1,175 @@
+# Phase 2.5 Semantic Frame Completion Plan
+
+## Purpose
+
+Phase 2 added the semantic-role metadata needed for decision-aware drafting, but the May 14, 2026 PDF review showed that the product behavior is not yet complete. The backend can attach semantic roles, confidence, reasons, polarity, controllability, and warnings to metrics and dimensions, but the active decision frame can still lose, under-parse, or misclassify prompt terms.
+
+Phase 2.5 exists to button up that gap before Phase 3 correction and ranked observational evidence. This is a backend-first reliability slice focused on making the prompt-first decision frame match the user's stated objective, levers, guardrails, segments, and thresholds.
+
+## Current Status
+
+Status: next Codex-owned backend slice after app-wide PDF export unification.
+
+The active branch immediately before this work is `project_docs/active/pdf_export_unification_plan.md`. Do not start Phase 2.5 until the PDF export work is complete enough that exported review artifacts accurately match visible AI Chat, Decisions workspace, chart, story, and report content.
+
+Phase 3 correction and ranked observational evidence remains planned, but it is deferred until Phase 2.5 is complete. Phase 3 should not be started while the current prompt-first frame can misclassify segmentation dimensions as levers or drop guardrail thresholds.
+
+## Review Evidence
+
+The review used the active test dataset:
+
+`D:/Data Bank/AI Tool Test Data/decision_intelligence_prompt_first_demo_clean_large.csv`
+
+The test prompt was:
+
+`How should we grow revenue next quarter using marketing_spend and discount_pct as controllable levers, segmented by region and channel, while keeping gross_margin_pct above 30% and return_rate_pct below 4%?`
+
+The exported PDFs showed that Decision Chat correctly routed to `decide`, generated a workspace preview, opened the Decisions workspace, and exposed Phase 2 semantic metadata in the raw workspace export. The raw contract included `decision_semantics`, `semantic_binding_confidence`, `semantic_binding_reason`, `semantic_role_source`, `semantic_role_warnings`, aliases, polarity, controllability, and role confidence.
+
+However, the active decision frame was not correct:
+
+`gross_margin_pct above 30%` was detected in prompt matches but did not become an active guardrail.
+
+`return_rate_pct below 4%` became an active guardrail, but its condition had `operator: "lte"` and `value: null`; the threshold value was lost.
+
+`region and channel` was not handled consistently as segmentation. The preview showed only `channel` as the segment, the workspace scoped context included `region`, and the draft also introduced `channel mix` as a controllable lever even though the prompt said `segmented by region and channel`.
+
+The chat preview said no unresolved mappings were reported even though the active frame was missing or misclassifying important prompt terms. That makes the frame look more reliable than it is.
+
+## Product Goal
+
+For clear prompt-first decision statements, the active decision frame should preserve the user's stated semantic roles without requiring a correction loop. If the user names objective, levers, guardrails, segments, and thresholds clearly, those items should appear in the active workspace preview and Decisions workspace with appropriate role metadata, confidence, reasons, and warnings.
+
+Phase 2.5 does not add simulation, optimization, autonomous decisioning, or final recommendation. It does not add the full Phase 3 correction loop. It makes the initial frame reliable enough that Phase 3 can build correction and ranked evidence on a sane state.
+
+## Implementation Scope
+
+### 1. Fix prompt-first frame extraction
+
+Inspect `backend/services/decision_workspace_service.py`, especially prompt-first drafting, prompt match selection, lever extraction, constraint extraction, segment extraction, condition parsing, and readiness evaluation.
+
+The exact May 14 test prompt must produce this active frame:
+
+Objective: `revenue`, direction `maximize`, horizon `Next quarter`.
+
+Levers: `marketing_spend` and `discount_pct`.
+
+Segments: `region` and `channel`.
+
+Guardrails: `gross_margin_pct above 30%` and `return_rate_pct below 4%`.
+
+`channel` must not become a controllable `channel mix` lever when it appears only inside `segmented by region and channel`.
+
+### 2. Preserve guardrail thresholds
+
+Guardrail condition parsing must preserve both operator and value. For the test prompt, `gross_margin_pct above 30%` should become a guardrail condition with a greater-than or greater-than-or-equal operator and the threshold value preserved. `return_rate_pct below 4%` should become a less-than or less-than-or-equal condition with the threshold value preserved.
+
+Use the existing contract shape where possible. If the current condition object represents percentages as `value: 30, unit: "%"`, preserve that convention consistently. Do not allow `analysis_ready` when a required hard guardrail has a null threshold value because parsing failed.
+
+### 3. Keep segment clauses out of lever extraction
+
+Segment-clause parsing should be role-aware. Terms introduced by phrases such as `segmented by`, `broken down by`, `by region and channel`, or `compare across` should bind to segment or comparison dimensions, not to controllable levers.
+
+The system can still support a true mix lever when the user explicitly says something like `change channel mix`, `shift channel mix`, or `optimize channel allocation`, but not when the term appears only in segmentation language.
+
+### 4. Make unresolved or omitted mappings truthful
+
+If a prompt term is detected but not included in the active frame, the backend should either include it in the correct role or surface a truthful unresolved or frame-omission detail. The UI and PDF export should not claim "No unresolved mappings" when a clearly detected term such as `gross_margin_pct` was not included in the active guardrails.
+
+Preserve Phase 2 traceability fields on active bindings: `semantic_binding_confidence`, `semantic_binding_reason`, `semantic_role_source`, and `semantic_role_warnings`.
+
+### 5. Tighten readiness semantics
+
+Readiness should be based on the active frame, not only on partial prompt matches. A decision with a hard guardrail whose threshold value failed to parse should be blocked or limited until resolved. A frame that drops one of two explicitly requested guardrails should not look fully reliable without warning.
+
+### 6. Use the unified PDF export for review
+
+Phase 2.5 should rely on the app-wide PDF export system completed immediately before this branch. Do not rebuild PDF export inside Phase 2.5. Use the unified export only to verify that AI Chat and Decisions workspace output match the active backend frame.
+
+## Tests To Add
+
+Add backend tests around the exact May 14 prompt and at least two nearby variants. Tests should assert the active workspace object, not just prompt matches.
+
+Required assertions for the exact prompt:
+
+The draft mode is `decide` or prompt-first workspace creation.
+
+The active objective metric is `revenue`.
+
+The active levers are exactly the intended controllable levers: `marketing_spend` and `discount_pct`.
+
+The active segment dimensions include both `region` and `channel`.
+
+The active guardrails include both `gross_margin_pct` and `return_rate_pct`.
+
+Both guardrail conditions preserve non-null threshold values and the correct direction.
+
+`channel mix` is not added as a lever unless the prompt explicitly asks to shift or change channel mix.
+
+`readiness_state` is not `analysis_ready` when a hard guardrail is missing a threshold value.
+
+Phase 2 semantic trace fields are present on active objective, lever, guardrail, and segment refs when available.
+
+## Files To Inspect First
+
+`backend/services/decision_workspace_service.py`
+
+`backend/decision_engine/chat_service.py`
+
+`backend/services/semantic_model.py`
+
+`tests/test_decision_workspace_service.py`
+
+`tests/test_decision_reliability_benchmark.py`
+
+`tests/test_semantic_role_strengthening.py`
+
+`project_docs/active/contracts/decision_objects.md`
+
+## Acceptance Criteria
+
+Phase 2.5 is complete when the exact May 14 prompt produces a correct active decision frame in both AI Chat `workspace_preview` and the opened Decisions workspace:
+
+Objective `revenue`.
+
+Levers `marketing_spend` and `discount_pct`.
+
+Segments `region` and `channel`.
+
+Guardrails `gross_margin_pct above 30%` and `return_rate_pct below 4%`.
+
+No false `channel mix` lever.
+
+No null threshold values for parsed guardrails.
+
+Truthful unresolved or omission details if any term cannot be safely bound.
+
+Existing observational-analysis-only boundary remains intact.
+
+Required verification:
+
+`python -m unittest tests.test_semantic_role_strengthening`
+
+`python -m unittest tests.test_decision_workspace_service`
+
+`python -m unittest tests.test_decision_reliability_benchmark`
+
+Any new Phase 2.5 test module or new test cases added for prompt-first semantic frame completion.
+
+If local interpreter dependency issues block one of these commands, use the bundled Python runtime where appropriate and document exactly what passed and what was blocked.
+
+## Documentation Updates Required
+
+When Phase 2.5 is implemented, update:
+
+`project_docs/active/status/decision_intelligence_execution_status.md`
+
+`project_docs/active/contracts/decision_objects.md` if condition, omission, or unresolved mapping fields change
+
+This plan if acceptance criteria or field names change during implementation
+
+Do not mark Phase 3 active again until this status file truthfully says Phase 2.5 is complete.
+
+## Stored Start Prompt For Later
+
+Start by reading AGENTS.md, project_docs/INDEX.md, project_docs/active/README.md, project_docs/active/status/decision_intelligence_execution_status.md, and project_docs/active/decision_intelligence/current/phase_2_5_semantic_frame_completion_plan.md. Implement Phase 2.5 backend-first after confirming app-wide PDF export unification is complete. The goal is to fix prompt-first semantic frame extraction so the exact May 14 real-dataset prompt preserves objective revenue, levers marketing_spend and discount_pct, segments region and channel, and guardrails gross_margin_pct above 30% plus return_rate_pct below 4% with non-null threshold values. Do not add a false channel mix lever when channel appears only in segmentation language. Preserve existing endpoint names, action IDs, artifact types, readiness fields, semantic trace fields, and the observational-analysis-only boundary. Update backend tests, project_docs/active/contracts/decision_objects.md if fields change, and active status docs truthfully. Do not edit frontend files unless explicitly authorized.

--- a/project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md
+++ b/project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md
@@ -1,0 +1,139 @@
+# Phase 3 Correction And Ranked Observational Evidence Plan
+
+## Purpose
+
+Phase 3 builds on the completed reliability and semantic-role foundation. The system can now identify decision objects with more explicit role metadata, confidence, trace reasons, and unresolved mapping details. The next step is to let users correct the frame before analysis and to make `Analyze workspace` return richer observational evidence without drifting into recommendations, simulation, optimization, or autonomous decisioning.
+
+## Current Status
+
+Status: active next Codex-owned backend slice.
+
+Owner: Codex for backend actions, contracts, tests, and documentation. Gemini owns frontend implementation after the backend contract stabilizes and Codex prepares a scoped handoff.
+
+Phase 2 backend is complete. Phase 2 frontend integration is functionally in place, but the latest Codex review found small Gemini-owned cleanup items: compact semantic refs should visibly surface role metadata, and modified frontend files should pass `git diff --check`. These cleanup items do not change the Phase 3 backend contract.
+
+## What Phase 2 Enables Now
+
+Users and agents can now inspect whether a mapped semantic object is acting as an objective, lever, guardrail, segment, comparison, or temporal field. Metric and dimension refs can carry confidence, aliases, business terms, polarity, controllability, and unresolved review reasons.
+
+Prompt-first decision drafting can now expose why a term was mapped, how confident the mapping is, and which prompt terms could not be safely resolved. This means Phase 3 can add correction actions against concrete frame elements instead of asking the frontend to infer intent from plain labels.
+
+## Non-Goals
+
+Do not add simulation, optimization, causal impact claims, autonomous decisioning, or final recommendations.
+
+Do not rank evidence as a recommended action order. Ranked observational evidence should mean evidence priority and diagnostic relevance, not “do this.”
+
+Do not make weak semantic mappings look certain. Corrections should preserve traceability and should not erase unresolved mapping history.
+
+Do not start with frontend implementation. Backend contracts and tests should stabilize first.
+
+## Implementation Scope
+
+Phase 3 has two backend-first tracks.
+
+### 1. Decision Frame Correction Loop
+
+Add deterministic correction actions for the current draft workspace frame. Corrections should be additive and session-state compatible with the existing Decision Chat action system.
+
+Correction actions should support objective metric, objective direction, time horizon, lever binding, lever controllability, guardrail binding, guardrail condition, segment dimension, and explicit removal or replacement of a mistaken mapping.
+
+Each correction should return updated workspace state, a short correction summary, updated readiness, updated allowed next actions, and trace metadata showing what changed. Corrections should use the same semantic confidence and unresolved-mapping language introduced in Phase 2.
+
+### 2. Ranked Observational Evidence
+
+Strengthen `Analyze workspace` output so it returns ordered diagnostics with evidence, scope, semantic coverage, assumptions, blockers, data-quality caveats, and limitations.
+
+Evidence should be ranked by diagnostic relevance to the corrected decision frame. The ranking should be explainable with fields such as relevance score, evidence strength, semantic coverage, data sufficiency, and limitation notes. The response must remain observational and should not choose an option for the user.
+
+## Candidate Contract Shape
+
+Use additive fields and preserve existing endpoint names, action IDs, artifact types, and compatibility fields.
+
+For correction actions, add or extend action payloads with:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `correction_type` | `string` | `objective_metric`, `objective_direction`, `time_horizon`, `lever_binding`, `lever_controllability`, `guardrail_binding`, `guardrail_condition`, `segment_dimension`, or `remove_mapping` |
+| `target_path` | `string` | Stable object path such as `decision_scope.objective.metric_ref` or `decision_scope.levers[0].binding` |
+| `replacement` | `object` | New metric ref, dimension ref, field binding, condition, or scalar value |
+| `reason` | `string \| null` | Optional user or system reason for the correction |
+
+For correction responses, add:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `correction_result` | `object` | Summary of applied change, previous value, new value, and affected readiness fields |
+| `decision_workspace` | `object` | Updated workspace, preserving existing shape |
+| `decision_readiness` | `object` | Updated readiness/capability truth |
+| `allowed_next_actions` | `string[]` | Backend-approved next action IDs |
+| `trace` | `object` | Correction source, timestamp, target path, semantic confidence, warnings, and unresolved details |
+
+For ranked observational evidence, add:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `ranked_diagnostics` | `object[]` | Ordered diagnostics scoped to the current decision frame |
+| `evidence_rank` | `integer` | 1-based rank within this analysis response |
+| `relevance_score` | `number` | 0.0 to 1.0 diagnostic relevance to the current frame |
+| `evidence_strength` | `string` | `strong`, `moderate`, `weak`, or `insufficient` |
+| `semantic_coverage` | `object` | Which objective, lever, guardrail, segment, and temporal refs contributed |
+| `limitations` | `string[]` | Caveats, missing data, unresolved mappings, or weak confidence |
+| `observational_boundary` | `string` | Current value should remain `observational_analysis_only` |
+
+Final field names should be confirmed against the existing chat action and workspace analysis code before updating `project_docs/active/contracts/decision_objects.md`.
+
+## Work Packages
+
+### 1. Audit Existing Action And Analysis Flow
+
+Inspect:
+
+| Area | Path |
+| --- | --- |
+| Chat action routing | `backend/decision_engine/chat_service.py` |
+| Workspace creation and readiness | `backend/services/decision_workspace_service.py` |
+| Existing decision support analysis | `backend/services/decision_support.py` |
+| Reliability benchmark | `tests/test_decision_reliability_benchmark.py` |
+| Workspace tests | `tests/test_decision_workspace_service.py` |
+| Contract docs | `project_docs/active/contracts/decision_objects.md` |
+
+### 2. Add Correction Fixtures And Tests
+
+Add tests for correcting a wrong objective, replacing a lever binding, marking a lever non-controllable, adding or replacing a guardrail, correcting a segment dimension, correcting a time horizon, removing an unsafe mapping, and verifying readiness updates after each correction.
+
+Tests should also protect against stale state by ensuring corrected workspace state is used by follow-up analysis and by scoped chat actions.
+
+### 3. Implement Backend Correction Actions
+
+Add backend-owned correction behavior through the existing action system where practical. Keep actions deterministic and explicit. Do not let free-form correction text mutate arbitrary workspace fields without a validated target path and replacement shape.
+
+### 4. Add Ranked Observational Evidence
+
+Extend workspace analysis with ranked diagnostics that explain what evidence matters and why. Use Phase 2 semantic roles and confidence as part of the ranking, but keep the language diagnostic rather than prescriptive.
+
+### 5. Update Contracts, Status, And Gemini Handoff
+
+Update `project_docs/active/contracts/decision_objects.md` with final correction and ranked-evidence fields.
+
+Update `project_docs/active/status/decision_intelligence_execution_status.md` with exactly what was implemented and which tests passed.
+
+After backend fields stabilize, create a scoped Gemini handoff under `project_docs/active/decision_intelligence/current/` that names the frontend files to inspect, the new fields to render, and the no-simulation/no-recommendation language boundary.
+
+## Acceptance Criteria
+
+Phase 3 is complete when users can correct key decision-frame elements through backend-owned actions, corrected state drives later analysis, and `Analyze workspace` returns ranked observational diagnostics with evidence, confidence, limitations, semantic coverage, and readiness-aware boundaries.
+
+Required verification:
+
+`python -m unittest tests.test_decision_reliability_benchmark`
+
+`python -m unittest tests.test_decision_workspace_service`
+
+Any new Phase 3 correction or ranked-evidence test module.
+
+If route-level chat tests remain blocked by local dependency visibility, document that honestly instead of marking them passed.
+
+## Start Prompt
+
+Implement Phase 3 from `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md`. Keep it backend-first. Add deterministic decision-frame correction actions and ranked observational evidence, preserving existing endpoint names, action IDs, artifact types, readiness fields, and the observational-analysis-only boundary. Use Phase 2 semantic role confidence and unresolved mapping trace where it helps correction and evidence ranking. Update backend tests, `project_docs/active/contracts/decision_objects.md`, and active status docs truthfully. Do not edit frontend files unless explicitly authorized.

--- a/project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md
+++ b/project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md
@@ -1,16 +1,18 @@
 # Phase 3 Correction And Ranked Observational Evidence Plan
 
+> DEFERRED: May 14, 2026 PDF review showed Phase 2 semantic metadata exists, but the active prompt-first decision frame still drops or misclassifies key semantic roles. Do not start Phase 3 until `project_docs/active/decision_intelligence/current/phase_2_5_semantic_frame_completion_plan.md` is complete.
+
 ## Purpose
 
 Phase 3 builds on the completed reliability and semantic-role foundation. The system can now identify decision objects with more explicit role metadata, confidence, trace reasons, and unresolved mapping details. The next step is to let users correct the frame before analysis and to make `Analyze workspace` return richer observational evidence without drifting into recommendations, simulation, optimization, or autonomous decisioning.
 
 ## Current Status
 
-Status: active next Codex-owned backend slice.
+Status: deferred until Phase 2.5 semantic frame completion is complete.
 
 Owner: Codex for backend actions, contracts, tests, and documentation. Gemini owns frontend implementation after the backend contract stabilizes and Codex prepares a scoped handoff.
 
-Phase 2 backend is complete. Phase 2 frontend integration is functionally in place, but the latest Codex review found small Gemini-owned cleanup items: compact semantic refs should visibly surface role metadata, and modified frontend files should pass `git diff --check`. These cleanup items do not change the Phase 3 backend contract.
+Phase 2 semantic metadata plumbing is implemented and frontend integration is functionally in place, but May 14 PDF review found active prompt-first frame defects that must be fixed first: dropped `gross_margin_pct` guardrail, null `return_rate_pct` threshold, inconsistent `region`/`channel` segmentation, and a false `channel mix` lever. These are tracked in `project_docs/active/decision_intelligence/current/phase_2_5_semantic_frame_completion_plan.md`.
 
 ## What Phase 2 Enables Now
 
@@ -134,6 +136,6 @@ Any new Phase 3 correction or ranked-evidence test module.
 
 If route-level chat tests remain blocked by local dependency visibility, document that honestly instead of marking them passed.
 
-## Start Prompt
+## Deferred Start Prompt
 
-Implement Phase 3 from `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md`. Keep it backend-first. Add deterministic decision-frame correction actions and ranked observational evidence, preserving existing endpoint names, action IDs, artifact types, readiness fields, and the observational-analysis-only boundary. Use Phase 2 semantic role confidence and unresolved mapping trace where it helps correction and evidence ranking. Update backend tests, `project_docs/active/contracts/decision_objects.md`, and active status docs truthfully. Do not edit frontend files unless explicitly authorized.
+Use this only after Phase 2.5 is complete: Implement Phase 3 from `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md`. Keep it backend-first. Add deterministic decision-frame correction actions and ranked observational evidence, preserving existing endpoint names, action IDs, artifact types, readiness fields, and the observational-analysis-only boundary. Use Phase 2 semantic role confidence and unresolved mapping trace where it helps correction and evidence ranking. Update backend tests, `project_docs/active/contracts/decision_objects.md`, and active status docs truthfully. Do not edit frontend files unless explicitly authorized.

--- a/project_docs/active/pdf_export_unification_plan.md
+++ b/project_docs/active/pdf_export_unification_plan.md
@@ -1,0 +1,121 @@
+# App-Wide PDF Export Unification Plan
+
+## Purpose
+
+The app needs one accurate, polished PDF export system used consistently across features. The first Decision Intelligence PDF export was useful for debugging, but it did not match the content visible in the AI Chat and Decisions workspace windows. It produced a clunky report with too much raw contract JSON, poor visual hierarchy, and a different reading experience from the actual UI.
+
+This plan makes PDF export the active next implementation slice before Phase 2.5 semantic frame completion.
+
+## Current Status
+
+Status: active next Codex implementation slice.
+
+The user explicitly wants this branch before Phase 2.5 because accurate exports make it much easier to share AI Chat, Decisions workspace, and other app results for review without screenshots. Phase 2.5 semantic frame completion remains next after this PDF export work is complete.
+
+## Product Goal
+
+PDF export should feel like a faithful, polished print/export version of what the user is looking at in the app. It should not be a lossy debug dump unless the user explicitly asks for a debug export.
+
+The exported PDF should match the visible feature content as closely as practical: same title, same section order, same cards or table structure, same labels, same selected result, same user-facing text, same semantic badges where visible, same chart or workspace result, and same current state. It should be compact, readable, visually aligned with the app, and reliable enough to use as the primary review artifact.
+
+## Why This Comes Before Phase 2.5
+
+The May 14 Decision Intelligence review depended on exported PDFs. The export did reveal backend frame problems, but the PDF itself was too sloppy and too different from the UI. Before continuing semantic frame reliability work, the app needs a trustworthy export layer so future reviews can compare exact UI output, exact workspace state, and exact generated evidence without relying on screenshots.
+
+## Scope
+
+This is app-wide export work, not only Decision Intelligence.
+
+Unify or replace the existing PDF export paths so the app does not have separate inconsistent implementations for charts, Data Story, AI Chat, Decisions, workflow reports, and file export.
+
+Relevant starting files include:
+
+`frontend/frontend/src/utils/pdfReportExport.js`
+
+`frontend/frontend/src/utils/decisionPdfExport.js`
+
+`frontend/frontend/src/features/charts/ChartToolbar.jsx`
+
+`frontend/frontend/src/components/insights/DataStoryPanel.jsx`
+
+`frontend/frontend/src/components/data_management/FileExport.jsx`
+
+`frontend/frontend/src/features/workflow/AIReporter.jsx`
+
+`frontend/frontend/src/features/ai/AIShell.jsx`
+
+`frontend/frontend/src/features/ai/AIShell.css`
+
+`frontend/frontend/src/features/business/decision/DecisionWorkspaceView.jsx`
+
+`frontend/frontend/src/features/business/decision/DecisionWorkspace.css`
+
+Search the frontend for all `jsPDF`, `html2canvas`, `Export PDF`, `Export as PDF`, `generateAnalyticalPdfReport`, and `generateDecisionWorkspacePdf` usage before changing behavior.
+
+## Required Behavior
+
+The export should be accurate to the window or result being exported. For AI Chat, exporting a workspace preview should export the visible workspace preview content, not an invented report. Exporting an Explore answer should export the visible answer card/table/chart. Exporting the active inspector result should export that inspector result. For Decisions workspace, exporting should match the current workspace view and include the visible analysis section if it is present.
+
+The export should use one shared app-wide export utility or framework with feature-specific adapters only where needed. Do not keep three unrelated PDF generation styles unless there is a documented reason.
+
+Raw JSON should not be included in the normal PDF by default. If raw contract details are useful, add a clearly named debug export option or an appendix mode. Normal export should prioritize the visible product result.
+
+The generated PDF should have a clean header, useful title, generated timestamp, page footer, consistent margins, compact spacing, and no giant debug blobs. It should avoid orphaned labels, excessive whitespace, broken long IDs, repeated boilerplate, and 10-page exports for one compact workspace preview.
+
+Icons should be cleaner than the old Data Story toolbar, consistent with the app's existing icon system, and accessible with clear `aria-label` values.
+
+## Suggested Technical Direction
+
+Prefer a shared export utility that can capture a known DOM region or render from a shared declarative export model. The important constraint is fidelity: the normal PDF should match what the user sees.
+
+For visual features, DOM capture or print-oriented HTML rendering may be more appropriate than manually reconstructing every field with `jsPDF.text`. If using `html2canvas`, handle scaling, background colors, scrollable regions, long content, and multipage splitting carefully. If using a print/HTML route, make sure it works in the current React app and does not require a backend service.
+
+For charts, preserve the rendered chart image and its visible title/toolbar context. For Data Story, preserve the current story/charts layout. For AI Chat and Decisions, preserve the visible artifact/workspace sections and semantic tags. If a feature has hidden state that matters, include it only when it is user-facing or explicitly selected for export.
+
+## Acceptance Criteria
+
+The app has one primary PDF export system used by all current PDF export entry points or a documented adapter layer that still produces consistent output.
+
+The Data Story PDF export remains available and looks at least as polished as before.
+
+Chart PDF export remains available and preserves the visible chart, title, and context.
+
+AI Chat exports are available for relevant results and match the visible result card or inspector content.
+
+Decisions workspace export matches the visible workspace content and visible analysis content when present.
+
+Normal PDFs do not include raw JSON dumps by default.
+
+Exports are compact and visually usable for review. A typical Decision Workspace preview should not become an 11-page debug document unless a debug export path is explicitly selected.
+
+Icon buttons have clear labels/tooltips and do not clutter the UI.
+
+`npm --prefix frontend\frontend run build` passes.
+
+Run `git diff --check` on touched files.
+
+If practical, use browser or Playwright verification to export at least one AI Chat result and one Decisions workspace result and inspect that the generated PDF corresponds to visible content.
+
+## Non-Goals
+
+Do not implement new Decision Intelligence semantics in this branch.
+
+Do not start Phase 2.5 semantic frame completion in this branch.
+
+Do not add simulation, optimization, autonomous decisioning, or final recommendation language.
+
+Do not redesign the entire app shell. Keep the work focused on accurate, reusable PDF export.
+
+## Documentation Updates Required
+
+When complete, update:
+
+`project_docs/active/status/decision_intelligence_execution_status.md`
+
+`project_docs/INDEX.md` and `project_docs/active/README.md` if the active next implementation path changes back to Phase 2.5
+
+Any export utility notes if a reusable export API is introduced
+
+## Start Prompt
+
+Start by reading AGENTS.md, project_docs/INDEX.md, project_docs/active/README.md, project_docs/active/status/decision_intelligence_execution_status.md, and project_docs/active/pdf_export_unification_plan.md. Implement app-wide PDF export unification before Phase 2.5. The export to PDF must accurately match the visible decision, chat, chart, story, or report content being exported; the first Decision Intelligence export was too clunky and did not match the window. Build one shared, polished export system or a clearly documented shared adapter layer used by all current PDF export entry points. Normal PDFs should not dump raw JSON by default; they should be compact, visually aligned with the app, accessible, and smooth. Preserve existing export entry points for charts, Data Story, AI Chat relevant artifacts, Decisions workspace, workflow reports, and file export where applicable. Use clean icon buttons with labels/tooltips. Verify with npm --prefix frontend\frontend run build and git diff --check on touched files. Do not implement Phase 2.5 semantic frame fixes in this branch.

--- a/project_docs/active/status/decision_intelligence_execution_status.md
+++ b/project_docs/active/status/decision_intelligence_execution_status.md
@@ -24,7 +24,11 @@ Before Codex edits frontend files for this initiative, re-read:
 
 May 9, 2026 Phase 1 reliability foundation completion: Codex added a repeatable Decision Intelligence benchmark suite with 20 prompt fixtures and grading checks for extraction, readiness, allowed and disabled actions, unsupported capability requests, and forbidden claims. Backend decision workspace and chat responses now include additive `decision_readiness`, `readiness_state`, `structural_readiness`, `blocked_state`, `allowed_next_actions`, `capability_state`, `unsupported_capabilities`, and `not_ready_for_recommendation` fields while preserving existing endpoint names, artifact types, action IDs, and compatibility fields. Gemini completed frontend consumption of those fields, including object-path normalization, response-level state preservation, and capability merging for requested unsupported capabilities. `ml_logic.py` now has a deterministic pandas-only anomaly fallback when scikit-learn is unavailable, because the current pinned requirements do not include scikit-learn.
 
-May 9, 2026 next implementation plan: Phase 2 semantic role strengthening is now the active next Codex slice at `project_docs/active/decision_intelligence/current/phase_2_semantic_role_strengthening_plan.md`.
+May 10, 2026 Phase 2 semantic role strengthening backend slice: Codex added additive `decision_semantics` metadata to finalized semantic metrics and dimensions, including objective, lever, guardrail, segment, comparison, temporal, aliases, business terms, polarity, controllability, conservative confidence, confidence reasons, and unresolved role-review reasons. Metric and dimension refs now echo this metadata when available. Prompt-first Decision Workspace drafting now carries `semantic_binding_confidence`, `semantic_binding_reason`, `semantic_role_source`, `semantic_role_warnings`, and `drafting.prompt_matches.unresolved_mappings` so weak or ambiguous semantic matches are visible instead of silently treated as certain. The resolver remains backward-compatible with older semantic models and still allows strong prompt evidence to resolve with warnings when role metadata is imperfect.
+
+May 11, 2026 Phase 2 semantic role strengthening frontend slice: Gemini integrated `SemanticRef` component across AI Shell and Decisions workspace, surfacing role metadata, confidence, trace reasons, warnings, unresolved mappings, and readable fallback labels for flattened workspace fields. Codex review confirmed the objective fallback regression is fixed and the frontend build compiles. Minor Gemini-owned cleanup remains: compact semantic refs should visibly surface role metadata, and modified frontend files should pass `git diff --check`.
+
+May 11, 2026 next implementation plan: Phase 3 correction and ranked observational evidence is now the active next Codex slice at `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md`.
 
 Slice 3 and Phase 4.5 Hardening are complete and verified.
 
@@ -41,7 +45,7 @@ The application has been hardened against UI flaws:
 - Source code has been polished: accidental working notes removed from `DecisionWorkspaceView.jsx`.
 - Dense styling for data cleaning controls has been restored.
 
-The frontend build is stable and passing.
+The frontend build compiles. Minor Gemini-owned Phase 2 frontend cleanup remains tracked in this status file.
 
 ### V2
 
@@ -70,13 +74,13 @@ Meaning:
 
 Status:
 
-- **OPEN THROUGH SEMANTIC ROLE PLAN**
+- **OPEN THROUGH PHASE 3 CORRECTION PLAN**
 
 Truth:
 
 - the prompt-first intake flow exists
 - backend hardening already covers the key objective-versus-lever parsing failure mode
-- prompt-first reliability is now grounded by the completed Phase 1 benchmark and will be strengthened through `project_docs/active/decision_intelligence/current/phase_2_semantic_role_strengthening_plan.md`
+- prompt-first reliability is now grounded by the completed Phase 1 benchmark and completed Phase 2 semantic-role strengthening. The next reliability layer is Phase 3 correction and ranked observational evidence at `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md`
 
 ### Phase 4 Chat Contract
 
@@ -102,14 +106,16 @@ Truth:
 - frontend Phase 1 reliability integration is complete and verified.
 - The UI correctly normalizes and merges reliability fields, ensuring that capability boundaries and requested unsupported features are surfaced truthfully.
 - State preservation and context propagation issues have been resolved.
-- Phase 2 semantic role strengthening is the next active implementation plan.
+- Phase 3 correction and ranked observational evidence is the next active implementation plan.
 
 ## Active Workstreams
 
 - [x] Council-derived next-focus execution plan created at `project_docs/active/decision_intelligence/current/next_focus_execution_plan.md`
 - [x] Phase 1 Decision Intelligence reliability foundation implemented and verified (Object-path, state-preservation, and capability-merging fixes applied)
-- [ ] Phase 2 semantic role strengthening: add decision-aware semantic roles, confidence, aliases, polarity, controllability, and unresolved mapping details
-- [~] Prompt-first intake reliability for real decision prompts, now tracked through the next-focus execution plan
+- [x] Phase 2 semantic role strengthening backend slice: additive semantic roles, confidence, aliases, polarity, controllability, prompt binding trace, and unresolved mapping details are implemented and covered by backend tests
+- [~] Phase 2 semantic role strengthening frontend cleanup: integration is in place and build compiles, but Codex review found compact role metadata visibility and trailing-whitespace cleanup still belong to Gemini
+- [ ] Phase 3 correction and ranked observational evidence backend slice: deterministic frame correction actions, corrected-state analysis, ranked observational diagnostics, contracts, tests, and Gemini handoff
+- [~] Prompt-first intake reliability for real decision prompts, now tracked through Phase 3 correction and ranked observational evidence
 - [x] Phase 4 backend decision chat contract
 - [x] Slice 1 backend mode/state normalization
 - [x] Slice 1 frontend fidelity (Mode legibility, Action fidelity, Artifact metadata, Rendering precision)
@@ -123,6 +129,12 @@ Truth:
 ## What Is Actually Implemented Today
 
 - **Phase 1 Reliability Foundation**: Backend reliability fields, benchmark fixtures, grading checks, and frontend rendering integration are complete.
+- **Phase 2 Semantic Role Strengthening**: Backend complete; frontend integration functionally in place with minor Gemini cleanup pending.
+  - **Backend**: Semantic model finalization now adds additive decision-aware role metadata for metrics and dimensions. Decision Workspace prompt-first drafting uses those roles as conservative binding evidence and surfaces confidence, reasons, warnings, and unresolved mappings for ambiguous or weak matches.
+  - **Frontend**: `SemanticRef` component integrated into Success Objective, Strategic Levers, Guardrails, Scoped Context, and AI Chat `workspace_preview`. Fixed fallback logic to ensure readable strings/labels (`label`, `binding_label`, `metric`, `dimension_id`) are preserved when real semantic references are missing. Unresolved mappings now render with labels combining `mapping_type`, reason, and candidate summaries. Remaining Gemini cleanup: compact semantic refs should visibly surface role metadata, and modified frontend files should pass `git diff --check`.
+- **Phase 3 Correction And Ranked Observational Evidence**: Active next plan created at `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md`.
+  - **Backend Goal**: Add deterministic correction actions for objective, lever, guardrail, segment, and horizon interpretation, then make corrected state drive follow-up analysis.
+  - **Evidence Goal**: Return ranked observational diagnostics with evidence, semantic coverage, data-quality caveats, assumptions, blockers, limitations, and the existing observational-analysis-only boundary.
 - **Phase 1 Reliability Foundation (Frontend)**: The UI now fully supports the backend reliability contract with correct object-path normalization, state preservation, and cross-level capability merging.
   - **Reliability Boundaries**: Clear visual banners and notes communicating the "observational analysis only" constraint.
   - **Capability Matrices**: A structured display of allowed vs. unsupported capabilities (Simulation, Optimization, etc.).
@@ -141,12 +153,17 @@ Truth:
 
 ## Verification Performed
 
-- **Frontend Build**: `npm --prefix frontend\frontend run build` executed and passed successfully on May 9, 2026.
+- **Frontend Build**: `npm --prefix frontend\frontend run build` executed and compiled successfully on May 11, 2026, with existing warnings.
+- **Phase 2 Frontend Integration Verification**: Verified that fallback labels for `objective_metric`, `levers`, `segment_dimensions`, and `guardrails` are preserved using flattened fields (`strings`, `label`, `binding_label`, `metric`, `dimension_id`, `field`) when nested refs are missing. Unresolved mappings in `workspace_preview` now build descriptive labels from type, term, reason, and candidates. Codex review still found that compact semantic refs hide visible role badges and that `git diff --check` fails on trailing whitespace in Gemini-modified frontend files.
 - **Git Compliance**: `git diff --check` executed and verified a clean codebase with no trailing whitespace on May 9, 2026.
 - **Capability Merging Check**: Code review confirmed that `AIShell.jsx` now correctly merges `unsupported_requested_capabilities` from both artifact and response sources, fixing the shadowing bug identified during review.
 - **Logic Check**: Verified that the "Observational Reliability Boundary" banner and "Analysis Ready" status are correctly driven by backend fields in both AI Shell and Decisions workspace.
 - **Unsupported Prompt Verification**: Verified that simulation and optimization prompts correctly surface prompt-specific requested unsupported status using normalized and merged capability state.
 - **Phase 1 Reliability Benchmark**: `tests.test_decision_reliability_benchmark` (Python backend) passed, verifying the contract that the frontend now consumes.
+- **Phase 2 Semantic Role Tests**: `tests.test_semantic_role_strengthening` passed on May 10, 2026 using the bundled Python runtime at `C:\Users\18022\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe`.
+- **Phase 2 Workspace Regression**: `tests.test_decision_workspace_service` passed on May 10, 2026 using the bundled Python runtime.
+- **Phase 2 Reliability Regression**: `tests.test_decision_reliability_benchmark` passed on May 10, 2026 using the bundled Python runtime.
+- **Local Python Caveat**: Plain `python -m unittest` under `C:\Program Files\Python311\python.exe` is currently blocked because the sandboxed interpreter cannot import dependencies that pip reports under the user-site package directory, including `pandas` and `dateutil`. `tests.test_decision_chat_service` is also blocked under the bundled runtime because Flask dependencies are not fully visible there (`flask`/`werkzeug` path issue). The backend semantic and workspace behavior was verified with the bundled Python runtime instead.
 - **Stale-Card Action Check**: Verified that action handling in `AIShell.jsx` uses message-scoped `session_state`.
 - **Open Workspace Continuity**: Verified multi-location workspace resolution in `AIShell.jsx`.
 
@@ -164,7 +181,8 @@ Truth:
 - `project_docs/active/status/decision_intelligence_execution_status.md`
 - `project_docs/active/rules/CODEX_FRONTEND_GUARDRAIL_READ_FIRST.md`
 - `project_docs/active/decision_intelligence/README.md`
-- `project_docs/active/decision_intelligence/current/phase_2_semantic_role_strengthening_plan.md`
+- `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md`
+- `project_docs/active/decision_intelligence/completed/phase_2_semantic_role_strengthening_plan.md`
 - `project_docs/active/decision_intelligence/current/next_focus_execution_plan.md`
 - `project_docs/active/agent_council/outputs/application-next-focus-priorities/README.md`
 - `project_docs/active/agent_council/outputs/application-next-focus-priorities/2026-05-01-council.json`
@@ -210,7 +228,7 @@ Council artifact:
 
 - `project_docs/active/agent_council/outputs/application-next-focus-priorities/2026-05-01-council.json`
 
-The council concluded that the next application focus should be measurable Decision Intelligence reliability before broad feature expansion. The highest-priority reliability foundation is now complete. The active follow-on priority is semantic role strengthening, then decision-frame correction, ranked observational evidence, canonical active dataset alignment, ML readiness diagnostics, and future simulation/trade-off contract design.
+The council concluded that the next application focus should be measurable Decision Intelligence reliability before broad feature expansion. The highest-priority reliability foundation and semantic role strengthening are now complete as backend foundations. The active follow-on priority is decision-frame correction and ranked observational evidence, then canonical active dataset alignment, ML readiness diagnostics, and future simulation/trade-off contract design.
 
 ### Previous Council Run
 
@@ -228,4 +246,4 @@ The council concluded that the first Gemini slice should focus on UI correctness
 
 ## One-Line Status Truth
 
-Decision Intelligence Phase 1 reliability foundation is complete. The active next slice is Phase 2 semantic role strengthening.
+Decision Intelligence Phase 3 correction and ranked observational evidence is the active next Codex backend slice; Phase 2 backend is complete, with minor Gemini frontend cleanup pending.

--- a/project_docs/active/status/decision_intelligence_execution_status.md
+++ b/project_docs/active/status/decision_intelligence_execution_status.md
@@ -28,7 +28,11 @@ May 10, 2026 Phase 2 semantic role strengthening backend slice: Codex added addi
 
 May 11, 2026 Phase 2 semantic role strengthening frontend slice: Gemini integrated `SemanticRef` component across AI Shell and Decisions workspace, surfacing role metadata, confidence, trace reasons, warnings, unresolved mappings, and readable fallback labels for flattened workspace fields. Codex review confirmed the objective fallback regression is fixed and the frontend build compiles. Minor Gemini-owned cleanup remains: compact semantic refs should visibly surface role metadata, and modified frontend files should pass `git diff --check`.
 
-May 11, 2026 next implementation plan: Phase 3 correction and ranked observational evidence is now the active next Codex slice at `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md`.
+May 14, 2026 Phase 2 product-behavior review: user-exported PDFs from AI Chat and Decisions workspace showed Phase 2 semantic metadata is present in raw contracts, but the active decision frame is not reliable enough to mark the product behavior complete. The test prompt was: "How should we grow revenue next quarter using marketing_spend and discount_pct as controllable levers, segmented by region and channel, while keeping gross_margin_pct above 30% and return_rate_pct below 4%?" The result correctly routed to `decide`, created a workspace, mapped objective `revenue`, and exposed semantic metadata such as `decision_semantics`, `semantic_binding_confidence`, `semantic_binding_reason`, `semantic_role_source`, polarity, controllability, aliases, and warnings. However, `gross_margin_pct above 30%` was detected only in prompt matches and did not become an active guardrail; `return_rate_pct below 4%` became a guardrail but lost its threshold value (`value: null`); `region and channel` was inconsistent, with only `channel` shown in the preview segment while `region` appeared only in scoped context; and `channel mix` was incorrectly introduced as a controllable lever even though the prompt used channel as segmentation. Phase 2.5 semantic frame completion was created at `project_docs/active/decision_intelligence/current/phase_2_5_semantic_frame_completion_plan.md` and is scheduled after app-wide PDF export unification.
+
+May 14, 2026 next implementation plan correction: Phase 3 correction and ranked observational evidence remains planned, but is deferred until Phase 2.5 fixes prompt-first semantic frame extraction and guardrail threshold preservation.
+
+May 14, 2026 PDF export correction: the first Decision Intelligence PDF export was useful for debugging but did not satisfy product-quality export behavior. The exported PDF did not accurately match the visible Decision or AI Chat window, was too clunky, dumped too much raw JSON, and was not compact or visually aligned with the app. The active next branch is now app-wide PDF export unification at `project_docs/active/pdf_export_unification_plan.md`. PDF export must be accurate, same-as-window where practical, reusable across all app features, polished, compact, and smooth. Phase 2.5 semantic frame completion is now scheduled immediately after the PDF export work.
 
 Slice 3 and Phase 4.5 Hardening are complete and verified.
 
@@ -80,7 +84,7 @@ Truth:
 
 - the prompt-first intake flow exists
 - backend hardening already covers the key objective-versus-lever parsing failure mode
-- prompt-first reliability is now grounded by the completed Phase 1 benchmark and completed Phase 2 semantic-role strengthening. The next reliability layer is Phase 3 correction and ranked observational evidence at `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md`
+- prompt-first reliability is grounded by the completed Phase 1 benchmark and Phase 2 semantic metadata, but May 14 PDF review showed the active prompt-first decision frame still needs Phase 2.5 completion before Phase 3. Before Phase 2.5 resumes, app-wide PDF export unification is active so future review artifacts accurately match visible app output.
 
 ### Phase 4 Chat Contract
 
@@ -106,16 +110,17 @@ Truth:
 - frontend Phase 1 reliability integration is complete and verified.
 - The UI correctly normalizes and merges reliability fields, ensuring that capability boundaries and requested unsupported features are surfaced truthfully.
 - State preservation and context propagation issues have been resolved.
-- Phase 3 correction and ranked observational evidence is the next active implementation plan.
+- App-wide PDF export unification is the next active implementation plan. Phase 2.5 semantic frame completion follows immediately after the PDF work. Phase 3 correction and ranked observational evidence is deferred until Phase 2.5 is complete.
 
 ## Active Workstreams
 
 - [x] Council-derived next-focus execution plan created at `project_docs/active/decision_intelligence/current/next_focus_execution_plan.md`
 - [x] Phase 1 Decision Intelligence reliability foundation implemented and verified (Object-path, state-preservation, and capability-merging fixes applied)
-- [x] Phase 2 semantic role strengthening backend slice: additive semantic roles, confidence, aliases, polarity, controllability, prompt binding trace, and unresolved mapping details are implemented and covered by backend tests
-- [~] Phase 2 semantic role strengthening frontend cleanup: integration is in place and build compiles, but Codex review found compact role metadata visibility and trailing-whitespace cleanup still belong to Gemini
-- [ ] Phase 3 correction and ranked observational evidence backend slice: deterministic frame correction actions, corrected-state analysis, ranked observational diagnostics, contracts, tests, and Gemini handoff
-- [~] Prompt-first intake reliability for real decision prompts, now tracked through Phase 3 correction and ranked observational evidence
+- [~] Phase 2 semantic role strengthening product completion: semantic metadata plumbing is implemented, but active prompt-first frame behavior is not complete because guardrails, thresholds, and segmentation can be dropped or misclassified
+- [ ] App-wide PDF export unification: make PDF export accurate to visible app content, shared across features, compact, polished, and not a raw JSON debug dump by default
+- [ ] Phase 2.5 semantic frame completion backend slice: next after PDF export; fix prompt-first role extraction so clear objective, lever, guardrail, segment, and threshold terms survive into the active workspace frame
+- [ ] Phase 3 correction and ranked observational evidence backend slice: deferred until Phase 2.5 is complete
+- [~] Prompt-first intake reliability for real decision prompts, now tracked through Phase 2.5 semantic frame completion
 - [x] Phase 4 backend decision chat contract
 - [x] Slice 1 backend mode/state normalization
 - [x] Slice 1 frontend fidelity (Mode legibility, Action fidelity, Artifact metadata, Rendering precision)
@@ -129,12 +134,19 @@ Truth:
 ## What Is Actually Implemented Today
 
 - **Phase 1 Reliability Foundation**: Backend reliability fields, benchmark fixtures, grading checks, and frontend rendering integration are complete.
-- **Phase 2 Semantic Role Strengthening**: Backend complete; frontend integration functionally in place with minor Gemini cleanup pending.
-  - **Backend**: Semantic model finalization now adds additive decision-aware role metadata for metrics and dimensions. Decision Workspace prompt-first drafting uses those roles as conservative binding evidence and surfaces confidence, reasons, warnings, and unresolved mappings for ambiguous or weak matches.
-  - **Frontend**: `SemanticRef` component integrated into Success Objective, Strategic Levers, Guardrails, Scoped Context, and AI Chat `workspace_preview`. Fixed fallback logic to ensure readable strings/labels (`label`, `binding_label`, `metric`, `dimension_id`) are preserved when real semantic references are missing. Unresolved mappings now render with labels combining `mapping_type`, reason, and candidate summaries. Remaining Gemini cleanup: compact semantic refs should visibly surface role metadata, and modified frontend files should pass `git diff --check`.
-- **Phase 3 Correction And Ranked Observational Evidence**: Active next plan created at `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md`.
-  - **Backend Goal**: Add deterministic correction actions for objective, lever, guardrail, segment, and horizon interpretation, then make corrected state drive follow-up analysis.
-  - **Evidence Goal**: Return ranked observational diagnostics with evidence, semantic coverage, data-quality caveats, assumptions, blockers, limitations, and the existing observational-analysis-only boundary.
+- **Phase 2 Semantic Role Strengthening**: Metadata plumbing is implemented, but product behavior is not complete.
+  - **Backend Foundation**: Semantic model finalization adds additive decision-aware role metadata for metrics and dimensions. Decision Workspace prompt-first drafting can surface confidence, reasons, warnings, and unresolved mappings for ambiguous or weak matches.
+  - **Behavior Gap Found May 14**: The exact real-dataset test prompt dropped `gross_margin_pct above 30%` from active guardrails, lost the `4%` threshold on `return_rate_pct`, treated only `channel` as the active preview segment while `region` appeared only in scoped context, and introduced `channel mix` as a lever even though the prompt used channel as segmentation.
+  - **Frontend State**: `SemanticRef` component integration and PDF export exist, but frontend rendering cannot compensate for an incorrect active backend frame.
+- **Phase 2.5 Semantic Frame Completion**: Active next plan created at `project_docs/active/decision_intelligence/current/phase_2_5_semantic_frame_completion_plan.md`.
+  - **Backend Goal**: Fix prompt-first role extraction so the active workspace frame preserves clearly stated objectives, levers, guardrails, segments, and threshold values.
+  - **Acceptance Prompt**: `How should we grow revenue next quarter using marketing_spend and discount_pct as controllable levers, segmented by region and channel, while keeping gross_margin_pct above 30% and return_rate_pct below 4%?`
+  - **Required Active Frame**: objective `revenue`; levers `marketing_spend` and `discount_pct`; segments `region` and `channel`; guardrails `gross_margin_pct above 30%` and `return_rate_pct below 4%`; no false `channel mix` lever; no null guardrail threshold values.
+- **App-Wide PDF Export Unification**: Active next plan created at `project_docs/active/pdf_export_unification_plan.md`.
+  - **Product Goal**: PDF export should accurately match the visible decision, chat, chart, story, or report content being exported. It should be compact, polished, reusable across features, and visually aligned with the app.
+  - **Known Defect**: The first Decision Intelligence export did not match the window closely enough, was too clunky, and dumped raw contract JSON into the normal PDF.
+  - **Sequencing**: Complete PDF export unification before returning to Phase 2.5 semantic frame completion.
+- **Phase 3 Correction And Ranked Observational Evidence**: Plan exists at `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md`, but it is deferred until Phase 2.5 is complete.
 - **Phase 1 Reliability Foundation (Frontend)**: The UI now fully supports the backend reliability contract with correct object-path normalization, state preservation, and cross-level capability merging.
   - **Reliability Boundaries**: Clear visual banners and notes communicating the "observational analysis only" constraint.
   - **Capability Matrices**: A structured display of allowed vs. unsupported capabilities (Simulation, Optimization, etc.).
@@ -154,7 +166,9 @@ Truth:
 ## Verification Performed
 
 - **Frontend Build**: `npm --prefix frontend\frontend run build` executed and compiled successfully on May 11, 2026, with existing warnings.
-- **Phase 2 Frontend Integration Verification**: Verified that fallback labels for `objective_metric`, `levers`, `segment_dimensions`, and `guardrails` are preserved using flattened fields (`strings`, `label`, `binding_label`, `metric`, `dimension_id`, `field`) when nested refs are missing. Unresolved mappings in `workspace_preview` now build descriptive labels from type, term, reason, and candidates. Codex review still found that compact semantic refs hide visible role badges and that `git diff --check` fails on trailing whitespace in Gemini-modified frontend files.
+- **Phase 2 Frontend Integration Verification**: Verified that fallback labels for `objective_metric`, `levers`, `segment_dimensions`, and `guardrails` are preserved using flattened fields (`strings`, `label`, `binding_label`, `metric`, `dimension_id`, `field`) when nested refs are missing. Unresolved mappings in `workspace_preview` now build descriptive labels from type, term, reason, and candidates. May 14 PDF review showed frontend/export visibility is now sufficient to diagnose backend frame defects, but the active backend frame remains wrong for the real acceptance prompt.
+- **May 14 PDF Review**: User exported `decision_ai_result_2026-05-14.pdf` and `decision_workspace_export_2026-05-14.pdf`. Codex extracted text from both PDFs and confirmed the decision routed to `decide`, semantic metadata exists, but the active frame omitted `gross_margin_pct` as a guardrail, lost the `return_rate_pct` threshold value, handled `region` and `channel` inconsistently as segments, and created an unwanted `channel mix` lever.
+- **May 14 Export Quality Review**: User clarified that the PDF export must exactly match the decision or chat content where practical. Normal export should be same-as-window, app-wide, visually smooth, compact, and accurate; it should not be a sloppy debug report.
 - **Git Compliance**: `git diff --check` executed and verified a clean codebase with no trailing whitespace on May 9, 2026.
 - **Capability Merging Check**: Code review confirmed that `AIShell.jsx` now correctly merges `unsupported_requested_capabilities` from both artifact and response sources, fixing the shadowing bug identified during review.
 - **Logic Check**: Verified that the "Observational Reliability Boundary" banner and "Analysis Ready" status are correctly driven by backend fields in both AI Shell and Decisions workspace.
@@ -180,7 +194,9 @@ Truth:
 - `project_docs/active/README.md`
 - `project_docs/active/status/decision_intelligence_execution_status.md`
 - `project_docs/active/rules/CODEX_FRONTEND_GUARDRAIL_READ_FIRST.md`
+- `project_docs/active/pdf_export_unification_plan.md`
 - `project_docs/active/decision_intelligence/README.md`
+- `project_docs/active/decision_intelligence/current/phase_2_5_semantic_frame_completion_plan.md`
 - `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md`
 - `project_docs/active/decision_intelligence/completed/phase_2_semantic_role_strengthening_plan.md`
 - `project_docs/active/decision_intelligence/current/next_focus_execution_plan.md`
@@ -228,7 +244,7 @@ Council artifact:
 
 - `project_docs/active/agent_council/outputs/application-next-focus-priorities/2026-05-01-council.json`
 
-The council concluded that the next application focus should be measurable Decision Intelligence reliability before broad feature expansion. The highest-priority reliability foundation and semantic role strengthening are now complete as backend foundations. The active follow-on priority is decision-frame correction and ranked observational evidence, then canonical active dataset alignment, ML readiness diagnostics, and future simulation/trade-off contract design.
+The council concluded that the next application focus should be measurable Decision Intelligence reliability before broad feature expansion. The highest-priority reliability foundation is complete, and semantic role metadata exists, but May 14 review showed prompt-first semantic frame behavior still needs Phase 2.5 completion before the ranked Phase 3 work. The user then moved app-wide PDF export unification ahead of Phase 2.5 so review artifacts can accurately match visible app content. After PDF export unification, the sequence returns to Phase 2.5, then decision-frame correction and ranked observational evidence, then canonical active dataset alignment, ML readiness diagnostics, and future simulation/trade-off contract design.
 
 ### Previous Council Run
 
@@ -246,4 +262,4 @@ The council concluded that the first Gemini slice should focus on UI correctness
 
 ## One-Line Status Truth
 
-Decision Intelligence Phase 3 correction and ranked observational evidence is the active next Codex backend slice; Phase 2 backend is complete, with minor Gemini frontend cleanup pending.
+App-wide PDF export unification is the active next Codex slice; Phase 2.5 semantic frame completion follows after export accuracy is fixed.

--- a/tests/test_semantic_role_strengthening.py
+++ b/tests/test_semantic_role_strengthening.py
@@ -1,0 +1,155 @@
+import unittest
+
+import pandas as pd
+
+from backend.services.decision_workspace_service import DecisionWorkspaceService
+from backend.services.semantic_model import finalize_semantic_model, infer_semantic_model_from_dataframe
+
+
+DATASET = [
+    {
+        "Order Date": "2026-01-31",
+        "Region": "East",
+        "Revenue": 100.0,
+        "Gross Margin %": 0.35,
+        "Discount Rate": 0.10,
+        "Marketing Spend": 24.0,
+    },
+    {
+        "Order Date": "2026-02-28",
+        "Region": "West",
+        "Revenue": 150.0,
+        "Gross Margin %": 0.32,
+        "Discount Rate": 0.07,
+        "Marketing Spend": 41.0,
+    },
+]
+
+
+def _metric_by_field(model, field):
+    return next(metric for metric in model["metrics"] if metric.get("field") == field)
+
+
+def _dimension_by_field(model, field):
+    return next(dimension for dimension in model["dimensions"] if dimension.get("field") == field)
+
+
+class SemanticRoleStrengtheningTests(unittest.TestCase):
+    def test_inferred_semantic_model_adds_decision_role_metadata(self):
+        model = infer_semantic_model_from_dataframe(pd.DataFrame(DATASET), dataset_name="Sales")
+
+        revenue_semantics = _metric_by_field(model, "Revenue")["decision_semantics"]
+        margin_semantics = _metric_by_field(model, "Gross Margin %")["decision_semantics"]
+        discount_semantics = _metric_by_field(model, "Discount Rate")["decision_semantics"]
+        date_semantics = _dimension_by_field(model, "Order Date")["decision_semantics"]
+        region_semantics = _dimension_by_field(model, "Region")["decision_semantics"]
+
+        # These assertions protect the additive contract rather than a single UI rendering path.
+        self.assertTrue(revenue_semantics["objective_candidate"])
+        self.assertEqual(revenue_semantics["polarity"], "increase_is_good")
+        self.assertGreaterEqual(revenue_semantics["confidence"], 0.7)
+        self.assertTrue(discount_semantics["lever_candidate"])
+        self.assertEqual(discount_semantics["controllability"], "controllable")
+        self.assertTrue(margin_semantics["guardrail_candidate"])
+        self.assertIn("Gross Margin %", margin_semantics["aliases"])
+        self.assertTrue(date_semantics["temporal_candidate"])
+        self.assertEqual(date_semantics["grain"], "observed_value")
+        self.assertTrue(region_semantics["segment_candidate"])
+        self.assertTrue(region_semantics["comparison_candidate"])
+
+    def test_prompt_first_workspace_carries_binding_confidence_and_role_source(self):
+        semantic_model = infer_semantic_model_from_dataframe(pd.DataFrame(DATASET), dataset_name="Sales")
+        result = DecisionWorkspaceService.create_workspace(
+            {
+                "dataset": DATASET,
+                "semantic_model": semantic_model,
+                "decision_prompt": "How should we grow revenue next quarter using marketing spend by region while protecting gross margin?",
+            }
+        )
+
+        workspace = result["decision_workspace"]
+        objective = workspace["decision_scope"]["objective"]
+        lever_bindings = [lever["binding"] for lever in workspace["decision_scope"]["levers"]]
+        guardrail_binding = workspace["decision_scope"]["constraints"][0]["binding"]
+        drafting_matches = workspace["drafting"]["prompt_matches"]
+
+        self.assertEqual(objective["metric_ref"]["field"], "Revenue")
+        self.assertGreaterEqual(objective["semantic_binding_confidence"], 0.7)
+        self.assertEqual(objective["semantic_role_source"], "decision_semantics")
+        self.assertTrue(any(binding.get("semantic_binding_confidence") for binding in lever_bindings))
+        self.assertEqual(guardrail_binding["metric_ref"]["field"], "Gross Margin %")
+        self.assertGreaterEqual(guardrail_binding["semantic_binding_confidence"], 0.7)
+        self.assertIn("unresolved_mappings", drafting_matches)
+
+    def test_weak_or_ambiguous_objective_mapping_stays_unresolved(self):
+        ambiguous_model = finalize_semantic_model(
+            {
+                "version": 2,
+                "dataset": {"id": "ambiguous_sales", "name": "Ambiguous Sales"},
+                "dimensions": [
+                    {
+                        "id": "dimension_region",
+                        "name": "Region",
+                        "label": "Region",
+                        "field": "Region",
+                        "semantic_kind": "categorical",
+                        "data_type": "string",
+                    }
+                ],
+                "metrics": [
+                    {
+                        "id": "metric_total_sales",
+                        "name": "Total Sales",
+                        "label": "Total Sales",
+                        "field": "Total Sales",
+                        "default_aggregation": "sum",
+                        "format_hint": "currency",
+                    },
+                    {
+                        "id": "metric_net_sales",
+                        "name": "Net Sales",
+                        "label": "Net Sales",
+                        "field": "Net Sales",
+                        "default_aggregation": "sum",
+                        "format_hint": "currency",
+                    },
+                    {
+                        "id": "metric_discount_rate",
+                        "name": "Discount Rate",
+                        "label": "Discount Rate",
+                        "field": "Discount Rate",
+                        "default_aggregation": "mean",
+                        "format_hint": "percentage",
+                    },
+                ],
+            }
+        )
+        dataset = [
+            {"Region": "East", "Total Sales": 100.0, "Net Sales": 90.0, "Discount Rate": 0.1},
+            {"Region": "West", "Total Sales": 120.0, "Net Sales": 110.0, "Discount Rate": 0.08},
+        ]
+
+        result = DecisionWorkspaceService.create_workspace(
+            {
+                "dataset": dataset,
+                "semantic_model": ambiguous_model,
+                "decision_prompt": "How should we grow sales next quarter using discount rate by region?",
+            }
+        )
+
+        workspace = result["decision_workspace"]
+        unresolved_mappings = workspace["drafting"]["prompt_matches"]["unresolved_mappings"]
+
+        self.assertIsNone(workspace["decision_scope"]["objective"]["metric_ref"])
+        self.assertIn("objective.metric_id_or_metric_name", workspace["readiness"]["missing_inputs"])
+        self.assertTrue(any(item["status"] == "ambiguous" for item in unresolved_mappings))
+        self.assertTrue(
+            any(
+                (lever.get("binding") or {}).get("metric_ref", {}).get("metric_id") == "metric_discount_rate"
+                for lever in workspace["decision_scope"]["levers"]
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Change the active next work from Phase 3 to an app-wide PDF export unification and add a Phase 2.5 semantic frame completion plan. Added project_docs/active/pdf_export_unification_plan.md and project_docs/active/decision_intelligence/current/phase_2_5_semantic_frame_completion_plan.md, updated AGENTS.md, project_docs/INDEX.md, active/README.md, next_focus_execution_plan.md, phase_3 plan, and the Decision Intelligence status doc to reflect the new sequencing and May 14 PDF review findings. Phase 3 (correction & ranked evidence) is deferred until Phase 2.5 is complete; PDF export work is explicitly authorized (including frontend export surfaces) to ensure exports match visible app content.