### PR TITLE
Emergency council branch

### DIFF
--- a/backend/decision_engine/chat_service.py
+++ b/backend/decision_engine/chat_service.py
@@ -287,6 +287,8 @@ class DecisionChatService:
         assistant_message = action_result["assistant_message"]
         warnings = list(action_result.get("warnings") or [])
         workspace = action_result["workspace"]
+        correction_result = action_result.get("correction_result")
+        correction_trace = action_result.get("trace")
 
         normalized_actions = DecisionChatService._normalize_available_actions(
             DecisionChatService._build_decision_actions(workspace) if workspace else [],
@@ -326,6 +328,8 @@ class DecisionChatService:
             "suggested_actions": normalized_actions,
             "artifacts": normalized_artifacts,
             "decision_workspace": workspace,
+            "correction_result": correction_result,
+            "trace": correction_trace,
             "session_state": updated_state,
             "warnings": warnings,
         }
@@ -892,6 +896,39 @@ class DecisionChatService:
         assistant_message = ""
 
         if action == "draft_workspace":
+            if isinstance(payload.get("correction"), dict):
+                if workspace is None:
+                    raise DecisionServiceError("A draft workspace is required before corrections can be applied.")
+                correction_payload = {
+                    "dataset": payload.get("dataset"),
+                    "dataset_ref": payload.get("dataset_ref") or payload.get("datasetRef"),
+                    "semantic_model": payload.get("semantic_model") or payload.get("semanticModel"),
+                    "decision_workspace": workspace,
+                    "correction": payload.get("correction"),
+                }
+                correction_result = DecisionWorkspaceService.correct_workspace(correction_payload)
+                workspace = correction_result.get("decision_workspace") or workspace
+                preview = DecisionChatService._build_workspace_preview(workspace)
+                artifacts.append({
+                    **preview,
+                    "action_id": action,
+                    "response_kind": action,
+                    "correction_result": correction_result.get("correction_result"),
+                    "trace": correction_result.get("trace"),
+                })
+                assistant_message = (
+                    (correction_result.get("correction_result") or {}).get("summary")
+                    or "The decision workspace correction was applied."
+                )
+                return {
+                    "artifacts": artifacts,
+                    "assistant_message": assistant_message,
+                    "workspace": workspace,
+                    "warnings": list(correction_result.get("warnings") or []),
+                    "correction_result": correction_result.get("correction_result"),
+                    "trace": correction_result.get("trace"),
+                }
+
             prompt = str(user_message or session_state.get("decision_prompt") or "").strip()
             if workspace is None:
                 if not prompt:
@@ -981,7 +1018,12 @@ class DecisionChatService:
                         or DecisionChatService._decision_truthfulness_note()
                     ),
                     "scoped_diagnostics": workspace_analysis.get("scoped_diagnostics") or [],
+                    "ranked_diagnostics": workspace_analysis.get("ranked_diagnostics") or [],
                     "legacy_diagnostics": workspace_analysis.get("legacy_diagnostics") or {},
+                    "observational_boundary": (
+                        workspace_analysis.get("observational_boundary")
+                        or "observational_analysis_only"
+                    ),
                 },
             ))
             assistant_message = summary_headline or "Workspace analysis completed using the current scoped draft."

--- a/backend/services/decision_workspace_service.py
+++ b/backend/services/decision_workspace_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import re
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
@@ -150,6 +151,51 @@ class DecisionWorkspaceService:
                 "generated_at": generated_at,
             },
             "warnings": warnings,
+        }
+
+    @staticmethod
+    def correct_workspace(payload: Dict[str, Any]) -> Dict[str, Any]:
+        payload = payload if isinstance(payload, dict) else {}
+        generated_at = iso_timestamp()
+        context = resolve_decision_context(
+            dataset=payload.get("dataset"),
+            dataset_ref=payload.get("dataset_ref") or payload.get("datasetRef"),
+            semantic_model=payload.get("semantic_model") or payload.get("semanticModel"),
+            source="decision_workspace_correction",
+        )
+        workspace = DecisionWorkspaceService._resolve_workspace_for_analysis(payload, context)
+        correction = DecisionWorkspaceService._normalize_correction_payload(payload)
+        corrected_workspace, correction_result = DecisionWorkspaceService._apply_workspace_correction(
+            workspace=workspace,
+            context=context,
+            correction=correction,
+            generated_at=generated_at,
+        )
+        readiness = corrected_workspace["readiness"]
+        trace = DecisionWorkspaceService._build_correction_trace(
+            correction=correction,
+            correction_result=correction_result,
+            generated_at=generated_at,
+        )
+
+        return {
+            "status": "success",
+            "contract_version": "di_2_0_v1",
+            "dataset": context["dataset"],
+            "semantic_model": build_semantic_summary(context["semantic_model"]),
+            "correction_result": correction_result,
+            "decision_workspace": corrected_workspace,
+            "decision_readiness": readiness,
+            "allowed_next_actions": list(readiness.get("allowed_next_actions") or []),
+            "trace": trace,
+            "meta": {
+                "intake_mode": ((corrected_workspace.get("drafting") or {}).get("intake_mode") or "structured"),
+                "relevant_metric_count": len(corrected_workspace["scoped_context"]["relevant_metrics"]),
+                "relevant_dimension_count": len(corrected_workspace["scoped_context"]["relevant_dimensions"]),
+                "unknown_count": len(corrected_workspace["unknowns"]),
+                "generated_at": generated_at,
+            },
+            "warnings": [],
         }
 
     @staticmethod
@@ -338,6 +384,453 @@ class DecisionWorkspaceService:
                 minimum=0,
                 maximum=DecisionWorkspaceService.MAX_SECONDARY_SIGNALS,
             ),
+        }
+
+    @staticmethod
+    def _normalize_correction_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
+        raw = payload.get("correction") if isinstance(payload.get("correction"), dict) else payload
+        correction_type = str(raw.get("correction_type") or raw.get("correctionType") or "").strip()
+        target_path = str(raw.get("target_path") or raw.get("targetPath") or "").strip()
+        if not correction_type:
+            raise DecisionServiceError("correction_type is required for decision workspace correction.")
+        if not target_path:
+            raise DecisionServiceError("target_path is required for decision workspace correction.")
+        replacement = raw.get("replacement")
+        if replacement is None and correction_type != "remove_mapping":
+            raise DecisionServiceError("replacement is required for decision workspace correction.")
+        if replacement is not None and not isinstance(replacement, (dict, bool, str, int, float)):
+            raise DecisionServiceError("replacement must be an object or scalar correction value.")
+
+        allowed_types = {
+            "objective_metric",
+            "objective_direction",
+            "time_horizon",
+            "lever_binding",
+            "lever_controllability",
+            "guardrail_binding",
+            "guardrail_condition",
+            "segment_dimension",
+            "remove_mapping",
+        }
+        if correction_type not in allowed_types:
+            raise DecisionServiceError(f"Unsupported correction_type: {correction_type}")
+
+        return {
+            "correction_type": correction_type,
+            "target_path": target_path,
+            "replacement": replacement,
+            "reason": DecisionWorkspaceService._clean_text(raw.get("reason")),
+        }
+
+    @staticmethod
+    def _apply_workspace_correction(
+        *,
+        workspace: Dict[str, Any],
+        context: Dict[str, Any],
+        correction: Dict[str, Any],
+        generated_at: str,
+    ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        corrected = copy.deepcopy(workspace)
+        decision_scope = corrected.get("decision_scope") if isinstance(corrected.get("decision_scope"), dict) else {}
+        correction_type = correction["correction_type"]
+        target_path = correction["target_path"]
+        replacement = correction.get("replacement")
+        previous_value: Any = None
+        new_value: Any = None
+
+        if correction_type == "objective_metric":
+            objective = decision_scope.get("objective") if isinstance(decision_scope.get("objective"), dict) else {}
+            previous_value = objective.get("metric_ref")
+            raw_objective = {
+                **objective,
+                **DecisionWorkspaceService._metric_replacement_to_raw(replacement, context),
+            }
+            normalized_objective = DecisionWorkspaceService._normalize_objective(raw_objective, context)
+            decision_scope["objective"] = normalized_objective
+            new_value = normalized_objective.get("metric_ref")
+
+        elif correction_type == "objective_direction":
+            objective = decision_scope.get("objective") if isinstance(decision_scope.get("objective"), dict) else {}
+            previous_value = objective.get("direction")
+            direction = DecisionWorkspaceService._scalar_replacement(
+                replacement,
+                key="direction",
+                allowed={"maximize", "minimize", "maintain", "achieve_target"},
+            )
+            objective["direction"] = direction
+            decision_scope["objective"] = objective
+            new_value = direction
+
+        elif correction_type == "time_horizon":
+            objective = decision_scope.get("objective") if isinstance(decision_scope.get("objective"), dict) else {}
+            previous_value = objective.get("time_horizon")
+            objective["time_horizon"] = DecisionWorkspaceService._normalize_time_horizon(replacement)
+            decision_scope["objective"] = objective
+            new_value = objective.get("time_horizon")
+
+        elif correction_type == "lever_binding":
+            index = DecisionWorkspaceService._require_path_index(target_path, "levers")
+            levers = list(decision_scope.get("levers") or [])
+            if index >= len(levers):
+                raise DecisionServiceError(f"target_path points to missing lever index {index}.")
+            previous_value = (levers[index].get("binding") if isinstance(levers[index], dict) else None)
+            raw_lever = {**levers[index], "binding": DecisionWorkspaceService._binding_replacement_to_raw(replacement)}
+            levers[index] = DecisionWorkspaceService._normalize_lever(raw_lever, context, index)
+            decision_scope["levers"] = levers
+            new_value = levers[index].get("binding")
+
+        elif correction_type == "lever_controllability":
+            index = DecisionWorkspaceService._require_path_index(target_path, "levers")
+            levers = list(decision_scope.get("levers") or [])
+            if index >= len(levers):
+                raise DecisionServiceError(f"target_path points to missing lever index {index}.")
+            previous_value = bool(levers[index].get("controllable"))
+            levers[index]["controllable"] = DecisionWorkspaceService._bool_replacement(replacement, "controllable")
+            decision_scope["levers"] = levers
+            new_value = bool(levers[index].get("controllable"))
+
+        elif correction_type == "guardrail_binding":
+            constraints = list(decision_scope.get("constraints") or [])
+            index = DecisionWorkspaceService._path_index(target_path, "constraints")
+            if index is None:
+                raw_constraint = DecisionWorkspaceService._guardrail_replacement_to_raw(replacement)
+                constraints.append(DecisionWorkspaceService._normalize_constraint(raw_constraint, context, len(constraints)))
+                new_value = constraints[-1]
+            else:
+                if index >= len(constraints):
+                    raise DecisionServiceError(f"target_path points to missing constraint index {index}.")
+                previous_value = constraints[index].get("binding")
+                raw_constraint = {
+                    **constraints[index],
+                    "binding": DecisionWorkspaceService._binding_replacement_to_raw(replacement),
+                }
+                constraints[index] = DecisionWorkspaceService._normalize_constraint(raw_constraint, context, index)
+                new_value = constraints[index].get("binding")
+            decision_scope["constraints"] = constraints
+
+        elif correction_type == "guardrail_condition":
+            constraints = list(decision_scope.get("constraints") or [])
+            index = DecisionWorkspaceService._require_path_index(target_path, "constraints")
+            if index >= len(constraints):
+                raise DecisionServiceError(f"target_path points to missing constraint index {index}.")
+            previous_value = constraints[index].get("condition")
+            raw_constraint = {**constraints[index], "condition": replacement}
+            constraints[index] = DecisionWorkspaceService._normalize_constraint(raw_constraint, context, index)
+            decision_scope["constraints"] = constraints
+            new_value = constraints[index].get("condition")
+
+        elif correction_type == "segment_dimension":
+            segments = list(decision_scope.get("segment_dimensions") or [])
+            index = DecisionWorkspaceService._path_index(target_path, "segment_dimensions")
+            raw_segment = DecisionWorkspaceService._segment_replacement_to_raw(replacement)
+            if index is None:
+                segments.append(DecisionWorkspaceService._normalize_segment_dimension(raw_segment, context, len(segments)))
+                new_value = segments[-1]
+            else:
+                if index >= len(segments):
+                    raise DecisionServiceError(f"target_path points to missing segment index {index}.")
+                previous_value = segments[index]
+                merged_segment = {**segments[index], **raw_segment}
+                segments[index] = DecisionWorkspaceService._normalize_segment_dimension(merged_segment, context, index)
+                new_value = segments[index]
+            decision_scope["segment_dimensions"] = segments
+
+        elif correction_type == "remove_mapping":
+            previous_value, new_value = DecisionWorkspaceService._remove_workspace_mapping(decision_scope, target_path, context)
+
+        corrected["decision_scope"] = decision_scope
+        corrected = DecisionWorkspaceService._rebuild_corrected_workspace(
+            workspace=corrected,
+            context=context,
+            correction=correction,
+            generated_at=generated_at,
+        )
+        readiness = corrected.get("readiness") if isinstance(corrected.get("readiness"), dict) else {}
+        correction_result = {
+            "status": "applied",
+            "correction_type": correction_type,
+            "target_path": target_path,
+            "summary": DecisionWorkspaceService._build_correction_summary(
+                correction_type=correction_type,
+                target_path=target_path,
+                previous_value=previous_value,
+                new_value=new_value,
+            ),
+            "previous_value": previous_value,
+            "new_value": new_value,
+            "affected_readiness_fields": [
+                "status",
+                "unknowns",
+                "readiness.readiness_state",
+                "readiness.missing_inputs",
+                "readiness.allowed_next_actions",
+            ],
+            "readiness_state": readiness.get("readiness_state"),
+            "allowed_next_actions": list(readiness.get("allowed_next_actions") or []),
+        }
+        return corrected, correction_result
+
+    @staticmethod
+    def _rebuild_corrected_workspace(
+        *,
+        workspace: Dict[str, Any],
+        context: Dict[str, Any],
+        correction: Dict[str, Any],
+        generated_at: str,
+    ) -> Dict[str, Any]:
+        decision_scope = workspace.get("decision_scope") if isinstance(workspace.get("decision_scope"), dict) else {}
+        objective = decision_scope.get("objective") if isinstance(decision_scope.get("objective"), dict) else {}
+        levers = list(decision_scope.get("levers") or [])
+        segment_dimensions = list(decision_scope.get("segment_dimensions") or [])
+        constraints = list(decision_scope.get("constraints") or [])
+        existing_scoped_context = workspace.get("scoped_context") if isinstance(workspace.get("scoped_context"), dict) else {}
+        applied_filters = list(existing_scoped_context.get("applied_filters") or [])
+        scope_preferences = {
+            "max_candidate_metrics": DecisionWorkspaceService.DEFAULT_MAX_METRICS,
+            "max_candidate_dimensions": DecisionWorkspaceService.DEFAULT_MAX_DIMENSIONS,
+            "include_diagnostics": False,
+        }
+        scoped_context = DecisionWorkspaceService._build_scoped_context(
+            context=context,
+            objective=objective,
+            levers=levers,
+            segment_dimensions=segment_dimensions,
+            constraints=constraints,
+            applied_filters=applied_filters,
+            scope_preferences=scope_preferences,
+        )
+        assumptions = DecisionWorkspaceService._generate_assumptions(
+            objective=objective,
+            levers=levers,
+            constraints=constraints,
+            scoped_context=scoped_context,
+        )
+        unknowns = DecisionWorkspaceService._generate_unknowns(
+            objective=objective,
+            levers=levers,
+            constraints=constraints,
+        )
+        readiness = DecisionWorkspaceService._evaluate_readiness(
+            objective=objective,
+            levers=levers,
+            constraints=constraints,
+            unknowns=unknowns,
+        )
+        correction_history = list(workspace.get("correction_history") or [])
+        correction_history.append({
+            "correction_type": correction["correction_type"],
+            "target_path": correction["target_path"],
+            "reason": correction.get("reason"),
+            "applied_at": generated_at,
+        })
+
+        rebuilt = dict(workspace)
+        rebuilt.update({
+            "status": DecisionWorkspaceService._derive_workspace_status(readiness),
+            "title": DecisionWorkspaceService._generate_title(objective),
+            "scope_summary": DecisionWorkspaceService._generate_scope_summary(objective, levers, constraints),
+            "scoped_context": scoped_context,
+            "assumptions": assumptions,
+            "unknowns": unknowns,
+            "readiness": readiness,
+            "correction_history": correction_history,
+        })
+        return rebuilt
+
+    @staticmethod
+    def _path_index(target_path: str, collection_name: str) -> Optional[int]:
+        patterns = [
+            rf"decision_scope\.{re.escape(collection_name)}\[(\d+)\]",
+            rf"decision_scope\.{re.escape(collection_name)}\.(\d+)",
+        ]
+        for pattern in patterns:
+            match = re.search(pattern, target_path)
+            if match:
+                return int(match.group(1))
+        return None
+
+    @staticmethod
+    def _require_path_index(target_path: str, collection_name: str) -> int:
+        index = DecisionWorkspaceService._path_index(target_path, collection_name)
+        if index is None:
+            raise DecisionServiceError(f"target_path must identify decision_scope.{collection_name}[index].")
+        return index
+
+    @staticmethod
+    def _metric_replacement_to_raw(replacement: Any, context: Dict[str, Any]) -> Dict[str, Any]:
+        raw = replacement if isinstance(replacement, dict) else {"metric_id": replacement}
+        metric_id = raw.get("metric_id") or raw.get("metricId")
+        metric_name = raw.get("metric_name") or raw.get("metricName") or raw.get("name") or raw.get("label")
+        field = raw.get("field")
+        if field and not metric_id and not metric_name:
+            metric = DecisionWorkspaceService._find_metric_by_field(context, str(field))
+            if metric:
+                metric_id = metric.get("id")
+            else:
+                metric_name = field
+        return {
+            "metric_id": metric_id,
+            "metric_name": metric_name,
+            "semantic_binding_confidence": raw.get("semantic_binding_confidence"),
+            "semantic_binding_reason": raw.get("semantic_binding_reason") or "User correction replaced the objective metric binding.",
+            "semantic_role_source": raw.get("semantic_role_source") or "user_correction",
+            "semantic_role_warnings": list(raw.get("semantic_role_warnings") or []),
+        }
+
+    @staticmethod
+    def _binding_replacement_to_raw(replacement: Any) -> Dict[str, Any]:
+        raw = replacement if isinstance(replacement, dict) else {}
+        if not raw:
+            raise DecisionServiceError("binding replacement must be an object.")
+        return {
+            "metric_id": raw.get("metric_id") or raw.get("metricId"),
+            "metric_name": raw.get("metric_name") or raw.get("metricName") or raw.get("name"),
+            "dimension_id": raw.get("dimension_id") or raw.get("dimensionId"),
+            "dimension_name": raw.get("dimension_name") or raw.get("dimensionName"),
+            "field": raw.get("field"),
+            "semantic_binding_confidence": raw.get("semantic_binding_confidence"),
+            "semantic_binding_reason": raw.get("semantic_binding_reason") or "User correction replaced the semantic binding.",
+            "semantic_role_source": raw.get("semantic_role_source") or "user_correction",
+            "semantic_role_warnings": list(raw.get("semantic_role_warnings") or []),
+        }
+
+    @staticmethod
+    def _guardrail_replacement_to_raw(replacement: Any) -> Dict[str, Any]:
+        raw = replacement if isinstance(replacement, dict) else {}
+        if not raw:
+            raise DecisionServiceError("guardrail replacement must be an object.")
+        label = str(raw.get("label") or raw.get("name") or raw.get("metric_name") or raw.get("metric_id") or "Corrected guardrail").strip()
+        condition = raw.get("condition") if isinstance(raw.get("condition"), dict) else None
+        if condition is None:
+            condition = {
+                "operator": raw.get("operator") or "gte",
+                "value": raw.get("value"),
+                "secondary_value": raw.get("secondary_value"),
+                "values": raw.get("values"),
+                "unit": raw.get("unit"),
+                "value_status": raw.get("value_status") or ("parsed" if raw.get("value") is not None else "not_specified"),
+            }
+        return {
+            "label": label,
+            "description": raw.get("description"),
+            "constraint_type": raw.get("constraint_type") or "metric_guardrail",
+            "binding": DecisionWorkspaceService._binding_replacement_to_raw(raw),
+            "condition": condition,
+            "hardness": raw.get("hardness") or "hard",
+            "rationale": raw.get("rationale"),
+        }
+
+    @staticmethod
+    def _segment_replacement_to_raw(replacement: Any) -> Dict[str, Any]:
+        raw = replacement if isinstance(replacement, dict) else {}
+        if not raw:
+            raise DecisionServiceError("segment replacement must be an object.")
+        label = str(raw.get("label") or raw.get("name") or raw.get("dimension_name") or raw.get("dimension_id") or raw.get("field") or "").strip()
+        return {
+            "label": label,
+            "segment_role": raw.get("segment_role") or "segment",
+            "binding": DecisionWorkspaceService._binding_replacement_to_raw(raw),
+        }
+
+    @staticmethod
+    def _scalar_replacement(replacement: Any, key: str, allowed: set[str]) -> str:
+        value = replacement.get(key) if isinstance(replacement, dict) else replacement
+        normalized = str(value or "").strip()
+        if normalized not in allowed:
+            raise DecisionServiceError(f"{key} must be one of: {', '.join(sorted(allowed))}.")
+        return normalized
+
+    @staticmethod
+    def _bool_replacement(replacement: Any, key: str) -> bool:
+        value = replacement.get(key) if isinstance(replacement, dict) else replacement
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str) and value.strip().lower() in {"true", "false"}:
+            return value.strip().lower() == "true"
+        raise DecisionServiceError(f"{key} must be a boolean correction value.")
+
+    @staticmethod
+    def _remove_workspace_mapping(
+        decision_scope: Dict[str, Any],
+        target_path: str,
+        context: Dict[str, Any],
+    ) -> Tuple[Any, Any]:
+        if "decision_scope.objective.metric_ref" in target_path:
+            objective = decision_scope.get("objective") if isinstance(decision_scope.get("objective"), dict) else {}
+            previous = objective.get("metric_ref")
+            raw_objective = {**objective, "metric_id": None, "metric_name": None}
+            raw_objective.pop("metric_ref", None)
+            decision_scope["objective"] = DecisionWorkspaceService._normalize_objective(raw_objective, context)
+            return previous, None
+
+        for collection_name in ("levers", "constraints", "segment_dimensions"):
+            index = DecisionWorkspaceService._path_index(target_path, collection_name)
+            if index is None:
+                continue
+            collection = list(decision_scope.get(collection_name) or [])
+            if index >= len(collection):
+                raise DecisionServiceError(f"target_path points to missing {collection_name} index {index}.")
+            previous = collection.pop(index)
+            decision_scope[collection_name] = collection
+            return previous, None
+
+        raise DecisionServiceError("remove_mapping target_path must point to objective.metric_ref, a lever, constraint, or segment_dimension.")
+
+    @staticmethod
+    def _build_correction_summary(
+        *,
+        correction_type: str,
+        target_path: str,
+        previous_value: Any,
+        new_value: Any,
+    ) -> str:
+        previous_label = DecisionWorkspaceService._display_value_label(previous_value) or "empty"
+        new_label = DecisionWorkspaceService._display_value_label(new_value) or "empty"
+        return f"Applied {correction_type} correction at {target_path}: {previous_label} -> {new_label}."
+
+    @staticmethod
+    def _display_value_label(value: Any) -> Optional[str]:
+        if isinstance(value, dict):
+            if not value:
+                return None
+            for key in ("label", "name", "field", "metric_id", "dimension_id", "status"):
+                if value.get(key):
+                    return str(value.get(key))
+            metric_ref = value.get("metric_ref") if isinstance(value.get("metric_ref"), dict) else {}
+            dimension_ref = value.get("dimension_ref") if isinstance(value.get("dimension_ref"), dict) else {}
+            return (
+                DecisionWorkspaceService._display_value_label(metric_ref)
+                or DecisionWorkspaceService._display_value_label(dimension_ref)
+            )
+        if value is None:
+            return None
+        return str(value)
+
+    @staticmethod
+    def _build_correction_trace(
+        *,
+        correction: Dict[str, Any],
+        correction_result: Dict[str, Any],
+        generated_at: str,
+    ) -> Dict[str, Any]:
+        new_value = correction_result.get("new_value")
+        trace_source = new_value if isinstance(new_value, dict) else {}
+        semantic_confidence = trace_source.get("semantic_binding_confidence")
+        if semantic_confidence is None and isinstance(trace_source.get("binding"), dict):
+            semantic_confidence = trace_source["binding"].get("semantic_binding_confidence")
+        warnings = list(trace_source.get("semantic_role_warnings") or [])
+        if isinstance(trace_source.get("binding"), dict):
+            warnings.extend(list(trace_source["binding"].get("semantic_role_warnings") or []))
+        return {
+            "source": "user_correction",
+            "timestamp": generated_at,
+            "correction_type": correction["correction_type"],
+            "target_path": correction["target_path"],
+            "reason": correction.get("reason"),
+            "semantic_confidence": semantic_confidence,
+            "warnings": DecisionWorkspaceService._dedupe_strings(warnings),
+            "unresolved_mappings": [],
+            "observational_boundary": "observational_analysis_only",
         }
 
     @staticmethod
@@ -2010,6 +2503,7 @@ class DecisionWorkspaceService:
             "unknowns": unknowns,
             "readiness": readiness,
             "drafting": drafting,
+            "correction_history": list(workspace.get("correction_history") or []),
             "created_at": workspace.get("created_at") or iso_timestamp(),
         }
 
@@ -2024,6 +2518,11 @@ class DecisionWorkspaceService:
         scoped_diagnostics = DecisionWorkspaceService._build_scoped_diagnostics(
             context=context,
             workspace=workspace,
+            generated_at=generated_at,
+        )
+        ranked_diagnostics = DecisionWorkspaceService._build_ranked_observational_diagnostics(
+            workspace=workspace,
+            scoped_diagnostics=scoped_diagnostics,
             generated_at=generated_at,
         )
         legacy_diagnostics, legacy_warnings = DecisionWorkspaceService._build_secondary_legacy_diagnostics(
@@ -2052,8 +2551,10 @@ class DecisionWorkspaceService:
                 ),
                 "truthfulness_note": "This response is descriptive and scope-grounded. It is not a simulation or trade-off result.",
                 "scoped_diagnostics": scoped_diagnostics,
+                "ranked_diagnostics": ranked_diagnostics,
                 "legacy_diagnostics": legacy_diagnostics,
                 "notes": notes,
+                "observational_boundary": "observational_analysis_only",
                 "generated_at": generated_at,
             },
             legacy_warnings,
@@ -2149,6 +2650,187 @@ class DecisionWorkspaceService:
             )
 
         return diagnostics
+
+    @staticmethod
+    def _build_ranked_observational_diagnostics(
+        *,
+        workspace: Dict[str, Any],
+        scoped_diagnostics: Sequence[Dict[str, Any]],
+        generated_at: str,
+    ) -> List[Dict[str, Any]]:
+        ranked: List[Dict[str, Any]] = []
+        for diagnostic in scoped_diagnostics:
+            rank_features = DecisionWorkspaceService._score_observational_diagnostic(workspace, diagnostic)
+            limitations = DecisionWorkspaceService._diagnostic_limitations(workspace, diagnostic, rank_features)
+            ranked.append(
+                {
+                    "diagnostic_id": diagnostic.get("diagnostic_id"),
+                    "diagnostic_type": diagnostic.get("diagnostic_type"),
+                    "status": diagnostic.get("status"),
+                    "summary": diagnostic.get("summary"),
+                    "source_diagnostic": diagnostic,
+                    "focus_role": diagnostic.get("focus_role"),
+                    "role_tags": list(diagnostic.get("role_tags") or []),
+                    "metric_ref": diagnostic.get("metric_ref"),
+                    "time_context": diagnostic.get("time_context"),
+                    "period_context": diagnostic.get("period_context"),
+                    "evidence": diagnostic.get("evidence"),
+                    "relevance_score": rank_features["relevance_score"],
+                    "evidence_strength": rank_features["evidence_strength"],
+                    "semantic_coverage": DecisionWorkspaceService._build_semantic_coverage(workspace, diagnostic),
+                    "data_sufficiency": rank_features["data_sufficiency"],
+                    "limitations": limitations,
+                    "observational_boundary": "observational_analysis_only",
+                    "generated_at": generated_at,
+                }
+            )
+
+        ranked.sort(
+            key=lambda item: (
+                -float(item.get("relevance_score") or 0.0),
+                {"strong": 3, "moderate": 2, "weak": 1, "insufficient": 0}.get(item.get("evidence_strength"), 0) * -1,
+                str(item.get("diagnostic_id") or ""),
+            )
+        )
+        for index, diagnostic in enumerate(ranked, start=1):
+            diagnostic["evidence_rank"] = index
+        return ranked
+
+    @staticmethod
+    def _score_observational_diagnostic(
+        workspace: Dict[str, Any],
+        diagnostic: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        role_tags = set(diagnostic.get("role_tags") or [])
+        role_weight = 0.45
+        if "objective" in role_tags:
+            role_weight = 0.96
+        elif "constraint" in role_tags:
+            role_weight = 0.88
+        elif "lever" in role_tags:
+            role_weight = 0.78
+        elif "context" in role_tags:
+            role_weight = 0.58
+
+        status = diagnostic.get("status")
+        evidence = diagnostic.get("evidence") if isinstance(diagnostic.get("evidence"), dict) else {}
+        row_count = evidence.get("row_count")
+        try:
+            row_count_float = float(row_count or 0)
+        except (TypeError, ValueError):
+            row_count_float = 0.0
+
+        if status == "observed_change" and row_count_float >= 2:
+            evidence_strength = "strong"
+            evidence_weight = 1.0
+        elif status == "observed_change":
+            evidence_strength = "moderate"
+            evidence_weight = 0.74
+        elif status == "insufficient_history":
+            evidence_strength = "weak"
+            evidence_weight = 0.38
+        else:
+            evidence_strength = "insufficient"
+            evidence_weight = 0.18
+
+        readiness = workspace.get("readiness") if isinstance(workspace.get("readiness"), dict) else {}
+        readiness_weight = 1.0 if readiness.get("readiness_state") == "analysis_ready" else 0.72
+        relevance_score = round(min(1.0, (role_weight * 0.58) + (evidence_weight * 0.32) + (readiness_weight * 0.10)), 2)
+
+        return {
+            "relevance_score": relevance_score,
+            "evidence_strength": evidence_strength,
+            "data_sufficiency": {
+                "status": "sufficient" if evidence_strength in {"strong", "moderate"} else "limited",
+                "row_count": row_count,
+                "has_period_comparison": status == "observed_change",
+            },
+        }
+
+    @staticmethod
+    def _build_semantic_coverage(workspace: Dict[str, Any], diagnostic: Dict[str, Any]) -> Dict[str, Any]:
+        decision_scope = workspace.get("decision_scope") if isinstance(workspace.get("decision_scope"), dict) else {}
+        metric_ref = diagnostic.get("metric_ref") if isinstance(diagnostic.get("metric_ref"), dict) else {}
+        metric_id = metric_ref.get("metric_id")
+        coverage = {
+            "objective": False,
+            "levers": [],
+            "guardrails": [],
+            "segments": [],
+            "temporal": bool(diagnostic.get("time_context")),
+            "semantic_confidences": [],
+        }
+
+        objective = decision_scope.get("objective") if isinstance(decision_scope.get("objective"), dict) else {}
+        objective_ref = objective.get("metric_ref") if isinstance(objective.get("metric_ref"), dict) else {}
+        if objective_ref.get("metric_id") == metric_id:
+            coverage["objective"] = True
+            if objective.get("semantic_binding_confidence") is not None:
+                coverage["semantic_confidences"].append(objective.get("semantic_binding_confidence"))
+
+        for lever in decision_scope.get("levers") or []:
+            binding = lever.get("binding") if isinstance(lever.get("binding"), dict) else {}
+            bound_metric = binding.get("metric_ref") if isinstance(binding.get("metric_ref"), dict) else {}
+            if bound_metric.get("metric_id") == metric_id:
+                coverage["levers"].append({
+                    "lever_id": lever.get("lever_id"),
+                    "label": lever.get("label"),
+                    "semantic_binding_confidence": binding.get("semantic_binding_confidence"),
+                })
+                if binding.get("semantic_binding_confidence") is not None:
+                    coverage["semantic_confidences"].append(binding.get("semantic_binding_confidence"))
+
+        for constraint in decision_scope.get("constraints") or []:
+            binding = constraint.get("binding") if isinstance(constraint.get("binding"), dict) else {}
+            bound_metric = binding.get("metric_ref") if isinstance(binding.get("metric_ref"), dict) else {}
+            if bound_metric.get("metric_id") == metric_id:
+                coverage["guardrails"].append({
+                    "constraint_id": constraint.get("constraint_id"),
+                    "label": constraint.get("label"),
+                    "condition": constraint.get("condition"),
+                    "semantic_binding_confidence": binding.get("semantic_binding_confidence"),
+                })
+                if binding.get("semantic_binding_confidence") is not None:
+                    coverage["semantic_confidences"].append(binding.get("semantic_binding_confidence"))
+
+        for segment in decision_scope.get("segment_dimensions") or []:
+            binding = segment.get("binding") if isinstance(segment.get("binding"), dict) else {}
+            dimension_ref = binding.get("dimension_ref") if isinstance(binding.get("dimension_ref"), dict) else {}
+            coverage["segments"].append({
+                "segment_id": segment.get("segment_id"),
+                "label": segment.get("label"),
+                "dimension_ref": dimension_ref or None,
+                "semantic_binding_confidence": binding.get("semantic_binding_confidence"),
+            })
+            if binding.get("semantic_binding_confidence") is not None:
+                coverage["semantic_confidences"].append(binding.get("semantic_binding_confidence"))
+
+        coverage["semantic_confidences"] = [
+            round(float(value), 2)
+            for value in coverage["semantic_confidences"]
+            if value is not None
+        ]
+        return coverage
+
+    @staticmethod
+    def _diagnostic_limitations(
+        workspace: Dict[str, Any],
+        diagnostic: Dict[str, Any],
+        rank_features: Dict[str, Any],
+    ) -> List[str]:
+        limitations: List[str] = []
+        readiness = workspace.get("readiness") if isinstance(workspace.get("readiness"), dict) else {}
+        if readiness.get("readiness_state") != "analysis_ready":
+            limitations.append("The decision frame is not structurally ready; evidence is descriptive only.")
+        if rank_features.get("evidence_strength") in {"weak", "insufficient"}:
+            limitations.append("The dataset did not provide strong period-over-period evidence for this diagnostic.")
+        if diagnostic.get("status") == "metric_unavailable":
+            limitations.append("The scoped semantic metric was not available in the current semantic model.")
+        metric_ref = diagnostic.get("metric_ref") if isinstance(diagnostic.get("metric_ref"), dict) else {}
+        warnings = list(metric_ref.get("semantic_role_warnings") or [])
+        limitations.extend(warnings)
+        limitations.append("This ranking is diagnostic relevance only; it is not a recommended action order.")
+        return DecisionWorkspaceService._dedupe_strings(limitations)
 
     @staticmethod
     def _collect_scoped_metric_refs(workspace: Dict[str, Any]) -> List[Dict[str, Any]]:

--- a/frontend/frontend/src/features/ai/AIShell.jsx
+++ b/frontend/frontend/src/features/ai/AIShell.jsx
@@ -422,6 +422,11 @@ function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspa
         // Backend now sends decision_kickoff as an object
         const isKickoff = !!wp.decision_kickoff;
 
+        // Phase 3: Check for additive correction_result in workspace_preview
+        const hasCorrection = !!wp.correction_result;
+        const cr_res = wp.correction_result;
+        const cr_trace = wp.trace;
+
         // Helper to format object arrays into SemanticRef components
         const renderSemanticList = (items, type) => {
           if (!Array.isArray(items) || items.length === 0) return <Typography variant="body2" sx={{ opacity: 0.5 }}>Not specified</Typography>;
@@ -459,6 +464,87 @@ function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspa
           <div className={`${baseClass} is-workspace_preview`}>
             <div className="ai-shell__artifact-content">
               {isInspector && renderArtifactExportBar(artifact, lookupSessionState, lookupCapabilityState, lookupDecisionReadiness)}
+              {/* Phase 3: Render Correction if present */}
+              {hasCorrection && (
+                <div className="ai-shell__correction-container" style={{ marginBottom: '32px', padding: '16px', background: 'rgba(0, 102, 255, 0.03)', borderRadius: '12px', border: '1px solid rgba(0, 102, 255, 0.1)' }}>
+                  <header style={{ marginBottom: '16px' }}>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '8px' }}>
+                      <Typography variant="overline" sx={{ fontWeight: 900, opacity: 0.5 }}>
+                        Correction Applied
+                      </Typography>
+                      {cr_res?.readiness_state && (
+                        <Chip
+                          label={cr_res.readiness_state.replace('_', ' ')}
+                          size="small"
+                          sx={{
+                            height: '18px',
+                            fontSize: '0.65rem',
+                            fontWeight: 900,
+                            textTransform: 'uppercase',
+                            bgcolor: cr_res.readiness_state === 'analysis_ready' ? 'rgba(34, 197, 94, 0.1)' : 'rgba(245, 158, 11, 0.1)',
+                            color: cr_res.readiness_state === 'analysis_ready' ? 'var(--accent-green)' : '#f59e0b',
+                            border: '1px solid currentColor'
+                          }}
+                        />
+                      )}
+                    </div>
+                    <Typography variant="subtitle2" sx={{ fontWeight: 800 }}>
+                      {cr_res?.summary || 'Workspace mapping updated'}
+                    </Typography>
+                  </header>
+
+                  <div style={{ display: 'grid', gridTemplateColumns: '100px 1fr', gap: '8px', fontSize: '0.8rem', marginBottom: '16px' }}>
+                    <Typography variant="caption" sx={{ fontWeight: 800, opacity: 0.5 }}>TARGET</Typography>
+                    <Typography variant="caption" sx={{ fontFamily: 'monospace' }}>{cr_res?.target_path}</Typography>
+                    <Typography variant="caption" sx={{ fontWeight: 800, opacity: 0.5 }}>PREVIOUS</Typography>
+                    <Typography variant="caption" sx={{ opacity: 0.6 }}>{typeof cr_res?.previous_value === 'object' ? JSON.stringify(cr_res.previous_value) : String(cr_res?.previous_value || 'None')}</Typography>
+                    <Typography variant="caption" sx={{ fontWeight: 800, opacity: 0.5, color: 'var(--accent-blue)' }}>NEW VALUE</Typography>
+                    <Typography variant="caption" sx={{ fontWeight: 700 }}>{typeof cr_res?.new_value === 'object' ? JSON.stringify(cr_res.new_value) : String(cr_res?.new_value)}</Typography>
+                  </div>
+
+                  {cr_trace && (
+                    <div style={{ borderTop: '1px solid rgba(0,0,0,0.05)', paddingTop: '12px' }}>
+                      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '12px', marginBottom: '8px' }}>
+                        {cr_trace.semantic_confidence !== undefined && (
+                          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                            <Typography variant="caption" sx={{ fontWeight: 800, opacity: 0.4 }}>CONFIDENCE</Typography>
+                            <Typography variant="caption" sx={{ fontWeight: 700 }}>{(cr_trace.semantic_confidence * 100).toFixed(0)}%</Typography>
+                          </div>
+                        )}
+                        {cr_trace.source && (
+                          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                            <Typography variant="caption" sx={{ fontWeight: 800, opacity: 0.4 }}>SOURCE</Typography>
+                            <Typography variant="caption" sx={{ fontWeight: 700 }}>{cr_trace.source.toUpperCase()}</Typography>
+                          </div>
+                        )}
+                        {cr_trace.observational_boundary && (
+                          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                            <Typography variant="caption" sx={{ fontWeight: 800, opacity: 0.4 }}>BOUNDARY</Typography>
+                            <Typography variant="caption" sx={{ fontWeight: 700, color: 'var(--accent-blue)' }}>{cr_trace.observational_boundary.replace('_', ' ').toUpperCase()}</Typography>
+                          </div>
+                        )}
+                      </div>
+
+                      {cr_trace.warnings?.length > 0 && (
+                        <div style={{ marginTop: '8px' }}>
+                          {cr_trace.warnings.map((w, i) => (
+                            <Typography key={i} variant="caption" sx={{ display: 'flex', alignItems: 'center', gap: '6px', color: '#f59e0b', fontWeight: 600, mb: 0.5 }}>
+                              <FaExclamationTriangle size={10} /> {w}
+                            </Typography>
+                          ))}
+                        </div>
+                      )}
+
+                      {cr_trace.timestamp && (
+                        <Typography variant="caption" sx={{ display: 'block', mt: 1, opacity: 0.3, fontSize: '0.65rem', textAlign: 'right' }}>
+                          Applied at {new Date(cr_trace.timestamp).toLocaleTimeString()}
+                        </Typography>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
+
               {isKickoff ? (
                 <div className="ai-shell__kickoff-container">
                   <header className="ai-shell__kickoff-header" style={{ marginBottom: '24px' }}>
@@ -672,11 +758,74 @@ function AIShell({ setShowAIChart, setAiChartType, setAiChartData, onOpenWorkspa
 
       case 'workspace_analysis_summary':
         const hasItems = content?.items && content.items.length > 0;
+        const rankedDiagnostics = content?.ranked_diagnostics || [];
+        const obsBoundary = content?.observational_boundary || content?.workspace_analysis?.observational_boundary;
+
         return (
           <div className={`${baseClass} is-workspace_analysis_summary`}>
             <div className="ai-shell__artifact-content">
               {isInspector && renderArtifactExportBar(artifact, lookupSessionState, lookupCapabilityState, lookupDecisionReadiness)}
-              {hasItems ? (
+
+              {rankedDiagnostics.length > 0 ? (
+                <div className="ai-shell__ranked-diagnostics" style={{ marginBottom: '32px' }}>
+                  <header style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '16px' }}>
+                    <Typography variant="overline" sx={{ fontWeight: 900, opacity: 0.5 }}>Ranked Observational Evidence</Typography>
+                    {obsBoundary && (
+                      <span style={{ fontSize: '0.65rem', fontWeight: 900, textTransform: 'uppercase', padding: '2px 8px', borderRadius: '4px', background: 'rgba(0, 102, 255, 0.05)', color: 'var(--accent-blue)', border: '1px solid var(--accent-blue)' }}>
+                        Observational Only
+                      </span>
+                    )}
+                  </header>
+                  <div className="ai-shell__analysis-list">
+                    {rankedDiagnostics.map((rd, i) => (
+                      <div key={i} className="ai-shell__analysis-item" style={{ marginBottom: '20px', padding: '16px', background: 'var(--bg-secondary)', borderRadius: '12px', border: '1px solid var(--border-color)' }}>
+                        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'start', marginBottom: '8px' }}>
+                          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                            <span style={{ width: '24px', height: '24px', borderRadius: '50%', background: 'var(--text-primary)', color: 'var(--bg-primary)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: '0.75rem', fontWeight: 900 }}>
+                              {rd.evidence_rank || (i + 1)}
+                            </span>
+                            <Typography variant="body2" sx={{ fontWeight: 800 }}>
+                              {rd.source_diagnostic?.headline || rd.source_diagnostic?.title || 'Observational Diagnostic'}
+                            </Typography>
+                          </div>
+                          <div className={`ai-shell__strength-badge is-${rd.evidence_strength}`} style={{ fontSize: '0.7rem', fontWeight: 800, padding: '2px 8px', borderRadius: '4px', border: '1px solid currentColor', opacity: 0.8 }}>
+                            {rd.evidence_strength?.toUpperCase()}
+                          </div>
+                        </div>
+
+                        <Typography variant="caption" sx={{ display: 'block', mb: 1.5, opacity: 0.8, lineHeight: 1.4 }}>
+                          {rd.source_diagnostic?.summary || rd.source_diagnostic?.description}
+                        </Typography>
+
+                        <div className="ai-shell__rd-meta" style={{ display: 'flex', flexWrap: 'wrap', gap: '12px', borderTop: '1px solid rgba(0,0,0,0.05)', paddingTop: '12px' }}>
+                          {rd.relevance_score !== undefined && (
+                            <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                              <Typography variant="caption" sx={{ fontWeight: 800, opacity: 0.4 }}>RELEVANCE</Typography>
+                              <Typography variant="caption" sx={{ fontWeight: 700 }}>{(rd.relevance_score * 100).toFixed(0)}%</Typography>
+                            </div>
+                          )}
+                          {rd.data_sufficiency?.status && (
+                            <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                              <Typography variant="caption" sx={{ fontWeight: 800, opacity: 0.4 }}>DATA</Typography>
+                              <Typography variant="caption" sx={{ fontWeight: 700, color: rd.data_sufficiency.status === 'sufficient' ? 'var(--accent-green)' : '#f59e0b' }}>
+                                {rd.data_sufficiency.status.toUpperCase()}
+                              </Typography>
+                            </div>
+                          )}
+                        </div>
+
+                        {rd.limitations?.length > 0 && (
+                          <div style={{ marginTop: '12px', padding: '8px', background: 'rgba(0,0,0,0.03)', borderRadius: '6px' }}>
+                            <Typography variant="caption" sx={{ fontStyle: 'italic', opacity: 0.6 }}>
+                              Limitations: {rd.limitations.join(' • ')}
+                            </Typography>
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : hasItems ? (
                 <div className="ai-shell__analysis-list">
                   <Typography variant="overline" sx={{ fontWeight: 900, mb: 2, display: 'block', opacity: 0.5 }}>Diagnostic Breakdown {artMode ? `• ${artMode.toUpperCase()}` : ''}</Typography>
                   {content.items.map((item, i) => {

--- a/frontend/frontend/src/features/business/decision/DecisionWorkspace.css
+++ b/frontend/frontend/src/features/business/decision/DecisionWorkspace.css
@@ -739,3 +739,126 @@
 .decision-workspace-pdf-capture .analysis-notice {
   margin-top: 12px !important;
 }
+
+/* Phase 3 Ranked Evidence & Corrections */
+.ranked-evidence-card {
+  display: flex;
+  gap: 20px;
+  padding: 24px;
+  background: var(--bg-secondary);
+  border-radius: 16px;
+  border: 1px solid var(--border-color);
+  margin-bottom: 20px;
+  transition: all 0.2s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.ranked-evidence-card:hover {
+  border-color: var(--text-secondary);
+  transform: translateY(-1px);
+}
+
+.evidence-rank-badge {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  background: var(--text-primary);
+  color: var(--bg-primary);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 900;
+  font-size: 0.9rem;
+}
+
+.evidence-content {
+  flex: 1;
+}
+
+.evidence-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.evidence-badges {
+  display: flex;
+  gap: 8px;
+}
+
+.strength-tag, .relevance-tag {
+  font-size: 0.65rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 4px 10px;
+  border-radius: 4px;
+  border: 1px solid var(--border-color);
+}
+
+.strength-tag.is-strong { color: var(--accent-green); border-color: var(--accent-green); background: rgba(34, 197, 94, 0.05); }
+.strength-tag.is-moderate { color: var(--accent-blue); border-color: var(--accent-blue); background: rgba(0, 102, 255, 0.05); }
+.strength-tag.is-weak { color: #f59e0b; border-color: #f59e0b; background: rgba(245, 158, 11, 0.05); }
+
+.relevance-tag {
+  background: var(--bg-primary);
+  opacity: 0.8;
+}
+
+.evidence-summary {
+  margin-bottom: 16px;
+  line-height: 1.6;
+  opacity: 0.9;
+}
+
+.evidence-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-top: 16px;
+  border-top: 1px solid rgba(0,0,0,0.05);
+}
+
+.meta-item {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.meta-item label {
+  font-size: 0.7rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  opacity: 0.5;
+  width: 120px;
+}
+
+.meta-item span {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.meta-item.limitations span {
+  font-style: italic;
+  opacity: 0.7;
+}
+
+.status--sufficient { color: var(--accent-green); }
+.status--insufficient { color: #ef4444; }
+
+/* Correction Artifact Styling in AI Shell */
+.ai-shell__correction-container {
+  padding: 4px;
+}
+
+.ai-shell__readiness-dot {
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.ai-shell__strength-badge.is-strong { color: var(--accent-green); }
+.ai-shell__strength-badge.is-moderate { color: var(--accent-blue); }
+.ai-shell__strength-badge.is-weak { color: #f59e0b; }

--- a/frontend/frontend/src/features/business/decision/DecisionWorkspaceView.jsx
+++ b/frontend/frontend/src/features/business/decision/DecisionWorkspaceView.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Typography from '@mui/material/Typography';
+import Chip from '@mui/material/Chip';
 import {
   FaCircleCheck, FaCircleExclamation, FaTriangleExclamation, FaCircleInfo,
   FaGears, FaShieldHalved, FaChartLine, FaLayerGroup, FaPlus, FaCalendarDays, FaFileLines, FaClock,
@@ -92,6 +93,129 @@ const ScopedDiagnosticCard = ({ diagnostic }) => {
       </div>
       <div className="diagnostic-summary">{summary}</div>
       {renderEvidence()}
+    </div>
+  );
+};
+
+/**
+ * RankedEvidenceCard
+ *
+ * Renders a high-fidelity ranked observational diagnostic item.
+ * Surfaces evidence strength, relevance, and data sufficiency.
+ */
+const RankedEvidenceCard = ({ rd }) => {
+  const {
+    evidence_rank,
+    relevance_score,
+    evidence_strength,
+    data_sufficiency,
+    limitations,
+    source_diagnostic,
+    semantic_coverage
+  } = rd;
+
+  const headline = source_diagnostic?.headline || source_diagnostic?.title || 'Observational Evidence';
+  const summary = source_diagnostic?.summary || source_diagnostic?.description;
+
+  const getLabel = (item) => {
+    if (!item) return '';
+    if (typeof item === 'string') return item;
+    return item.label || item.lever_id || item.constraint_id || item.segment_id || item.dimension_ref?.label || item.dimension_ref?.field || 'Unknown item';
+  };
+
+  return (
+    <div className={`ranked-evidence-card strength--${evidence_strength}`}>
+      <div className="evidence-rank-badge">{evidence_rank}</div>
+      <div className="evidence-content">
+        <div className="evidence-header">
+          <Typography variant="subtitle1" sx={{ fontWeight: 800 }}>{headline}</Typography>
+          <div className="evidence-badges">
+            <span className={`strength-tag is-${evidence_strength}`}>{evidence_strength} Evidence</span>
+            {relevance_score !== undefined && (
+              <span className="relevance-tag">{(relevance_score * 100).toFixed(0)}% Relevance</span>
+            )}
+          </div>
+        </div>
+
+        {summary && <Typography variant="body2" className="evidence-summary">{summary}</Typography>}
+
+        {semantic_coverage && (
+          <div className="evidence-coverage" style={{ marginBottom: '16px', padding: '12px', background: 'rgba(0, 102, 255, 0.03)', borderRadius: '8px', border: '1px solid rgba(0, 102, 255, 0.05)' }}>
+            <Typography variant="overline" sx={{ fontWeight: 900, opacity: 0.5, display: 'block', mb: 1, letterSpacing: '0.1em' }}>
+              Semantic Coverage
+            </Typography>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '12px 24px' }}>
+              <div className="coverage-item">
+                <label style={{ fontSize: '0.65rem', fontWeight: 900, opacity: 0.4, textTransform: 'uppercase', display: 'block' }}>Core</label>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginTop: '4px' }}>
+                  <Chip
+                    label="Objective"
+                    size="small"
+                    variant={semantic_coverage.objective ? "filled" : "outlined"}
+                    sx={{
+                      height: '20px',
+                      fontSize: '0.7rem',
+                      fontWeight: 700,
+                      bgcolor: semantic_coverage.objective ? 'var(--accent-blue)' : 'transparent',
+                      color: semantic_coverage.objective ? 'white' : 'inherit',
+                      opacity: semantic_coverage.objective ? 1 : 0.3
+                    }}
+                  />
+                  {semantic_coverage.temporal && (
+                    <Chip
+                      label="Temporal"
+                      size="small"
+                      sx={{ height: '20px', fontSize: '0.7rem', fontWeight: 700, bgcolor: 'rgba(0,0,0,0.05)' }}
+                    />
+                  )}
+                </div>
+              </div>
+
+              {(semantic_coverage.levers?.length > 0 || semantic_coverage.segments?.length > 0 || semantic_coverage.guardrails?.length > 0) && (
+                <div className="coverage-item">
+                  <label style={{ fontSize: '0.65rem', fontWeight: 900, opacity: 0.4, textTransform: 'uppercase', display: 'block' }}>Scope Covered</label>
+                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px', marginTop: '4px' }}>
+                    {semantic_coverage.levers?.map((l, i) => <Chip key={i} label={getLabel(l)} size="small" variant="outlined" sx={{ height: '18px', fontSize: '0.65rem', fontWeight: 600, borderStyle: 'dashed' }} />)}
+                    {semantic_coverage.segments?.map((s, i) => <Chip key={i} label={getLabel(s)} size="small" variant="outlined" sx={{ height: '18px', fontSize: '0.65rem', fontWeight: 600, bgcolor: 'rgba(0,0,0,0.03)' }} />)}
+                    {semantic_coverage.guardrails?.map((g, i) => <Chip key={i} label={getLabel(g)} size="small" variant="outlined" sx={{ height: '18px', fontSize: '0.65rem', fontWeight: 600, color: '#f59e0b' }} />)}
+                  </div>
+                </div>
+              )}
+
+              {Array.isArray(semantic_coverage.semantic_confidences) && semantic_coverage.semantic_confidences.length > 0 && (
+                <div className="coverage-item">
+                  <label style={{ fontSize: '0.65rem', fontWeight: 900, opacity: 0.4, textTransform: 'uppercase', display: 'block' }}>Confidences</label>
+                  <div style={{ display: 'flex', gap: '12px', marginTop: '4px' }}>
+                    {semantic_coverage.semantic_confidences.map((v, i) => (
+                      <div key={i} style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                        <span style={{ fontSize: '0.65rem', fontWeight: 900, color: v > 0.8 ? 'var(--accent-green)' : v > 0.5 ? 'var(--accent-blue)' : '#f59e0b' }}>
+                          {(v * 100).toFixed(0)}%
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        <div className="evidence-meta">
+
+          {data_sufficiency?.status && (
+            <div className="meta-item">
+              <label>Data Sufficiency</label>
+              <span className={`status--${data_sufficiency.status}`}>{data_sufficiency.status}</span>
+            </div>
+          )}
+          {limitations?.length > 0 && (
+            <div className="meta-item limitations">
+              <label>Limitations</label>
+              <span>{limitations.join(' • ')}</span>
+            </div>
+          )}
+        </div>
+      </div>
     </div>
   );
 };
@@ -623,6 +747,26 @@ const DecisionWorkspaceView = ({ workspace, analysis, onCreateNew, onAnalyze, se
           </div>
 
           <div className="analysis-grid" style={{ display: 'grid', gridTemplateColumns: '1fr', gap: '32px' }}>
+            {/* Ranked Observational Evidence: Phase 3 */}
+            {analysis.ranked_diagnostics?.length > 0 && (
+              <section className="analysis-section--ranked">
+                <h4 className="section-label" style={{ display: 'flex', alignItems: 'center', gap: '8px', color: 'var(--text-primary)' }}>
+                  <FaScaleBalanced /> Ranked Observational Evidence
+                </h4>
+                <div className="ranked-evidence-list">
+                  {analysis.ranked_diagnostics.map((rd, idx) => (
+                    <RankedEvidenceCard key={idx} rd={rd} />
+                  ))}
+                </div>
+                {analysis.observational_boundary && (
+                  <div className="analysis-notice" style={{ marginTop: '16px', opacity: 0.6, fontSize: '0.75rem' }}>
+                    <FaShieldHalved style={{ marginRight: '6px' }} />
+                    Ranking is by diagnostic relevance only. This is not a recommended action order or causal projection.
+                  </div>
+                )}
+              </section>
+            )}
+
             {/* Scoped Diagnostics: Primary Area */}
             <section className="analysis-section--primary">
               <h4 className="section-label" style={{ display: 'flex', alignItems: 'center', gap: '8px', color: 'var(--accent-blue)' }}>

--- a/project_docs/INDEX.md
+++ b/project_docs/INDEX.md
@@ -26,8 +26,11 @@ After those files, read only the task-specific document listed below.
 | Work on decision object contracts | `project_docs/active/contracts/decision_objects.md` |
 | Work inside Decision Intelligence docs | `project_docs/active/decision_intelligence/README.md` first, then only the named file under `current/` or `completed/` |
 | Review frontend state architecture | `project_docs/active/reviews/react_state_flow_review.md` |
+| Review Gemini frontend work | `project_docs/active/rules/CODEX_FRONTEND_GUARDRAIL_READ_FIRST.md`, then the active handoff only |
 | Review active Codex/Gemini handoffs | `project_docs/active/ai_hand_off/README.md` |
+| Start Phase 4 canonical active dataset work | `project_docs/active/decision_intelligence/current/next_focus_execution_plan.md`, then `project_docs/active/ai_hand_off/phase_4_gemini_frontend_canonical_active_dataset.md` |
 | Run or modify Agent Council workflow | `project_docs/active/agent_council/README.md` |
+| Run compounding-results council | `project_docs/active/agent_council/outputs/compounding-phase-results/README.md` |
 
 ## Current Project Truth
 
@@ -35,7 +38,7 @@ Decision Intelligence V3 is active. V2 is closed as-is and lives as historical c
 
 Phase 4.5 AI Chat Decision Intelligence hardening is complete. The product now has real chat-to-decision continuity, scoped action behavior, truthful observational-analysis language, and verified frontend hardening.
 
-The next work is not broad frontend polish and not new simulation or optimization. Phase 1 reliability foundation is complete. Phase 2 semantic metadata plumbing is implemented. Phase 2.5 backend semantic frame completion and Gemini frontend segment rendering are complete and verified for the May 14 acceptance prompt. The Gemini handoff at `project_docs/active/ai_hand_off/phase_2_5_gemini_frontend_segment_dimensions.md` is now a completed record, not an active implementation request. Phase 3 correction and ranked observational evidence is the next backend-first slice and should begin only when the user explicitly starts it. Frontend implementation remains Gemini-owned unless the user explicitly authorizes Codex frontend edits in the current session.
+The next work is not broad frontend polish and not new simulation or optimization. Phase 1 reliability foundation is complete. Phase 2 semantic metadata plumbing is implemented. Phase 2.5 backend semantic frame completion and Gemini frontend segment rendering are complete and verified for the May 14 acceptance prompt. Phase 3 backend correction actions and ranked observational evidence are implemented and verified, and Gemini frontend rendering for Correction Results and Ranked Observational Evidence is complete as of May 22, 2026. The next active roadmap item is Phase 4: Canonical Active Dataset Contract, which means aligning dataset truth across AI Chat, Decisions, charts, dashboards, workflows, filters, cleaning, uploads, and semantic model consumers. Frontend implementation remains Gemini-owned unless the user explicitly authorizes Codex frontend edits in the current session.
 
 ## Folder Map
 

--- a/project_docs/active/README.md
+++ b/project_docs/active/README.md
@@ -16,17 +16,19 @@ Its job is to stop agents from scanning old plans, completed handoffs, and archi
 | 6 | `project_docs/active/decision_intelligence/current/phase_2_5_semantic_frame_completion_plan.md` | Completed backend-first semantic frame completion plan. |
 | 7 | `project_docs/active/ai_hand_off/README.md` | Codex/Gemini handoff folder and ownership rules. |
 | 8 | `project_docs/active/ai_hand_off/phase_2_5_gemini_frontend_segment_dimensions.md` | Completed Gemini frontend handoff record for Phase 2.5 segment rendering. |
-| 9 | `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md` | Deferred next plan after Phase 2.5 completion. |
-| 10 | `project_docs/active/decision_intelligence/current/next_focus_execution_plan.md` | Council-derived roadmap and later-phase sequencing. |
+| 9 | `project_docs/active/decision_intelligence/current/next_focus_execution_plan.md` | Council-derived roadmap and Phase 4 canonical active dataset sequencing. |
+| 10 | `project_docs/active/ai_hand_off/phase_4_gemini_frontend_canonical_active_dataset.md` | Active Phase 4 Gemini frontend handoff. |
 | 11 | `project_docs/active/contracts/decision_objects.md` | Current backend/frontend decision object contract reference. |
 
 Do not start by reading every file in `project_docs/active/decision_intelligence/`. That folder now has a README plus `current/` and `completed/` subfolders. Read the README first and open only the specific file needed.
+
+For Gemini frontend reviews, use the fast path in `project_docs/active/rules/CODEX_FRONTEND_GUARDRAIL_READ_FIRST.md`: targeted contract search and focused diff first, no repeated build or browser pass unless the first pass finds a concrete reason.
 
 ## Current Project Truth
 
 Decision Intelligence V3 is the active product line. Phase 4.5 AI Chat hardening is complete. The app has a real backend chat contract, grounded `ask`, `explore`, and `decide` modes, real action handling, chat-to-Decisions continuity, truthful observational-analysis language, and improved artifact rendering.
 
-Phase 1 reliability foundation is complete. Phase 2 semantic metadata plumbing is implemented, and Gemini frontend integration is functionally in place. Phase 2.5 semantic frame completion is complete and verified on the backend and frontend. The opened Decisions workspace renders `decision_scope.segment_dimensions` as first-class decision-frame information. No Phase 2.5 Gemini implementation handoff is currently active. Phase 3 correction and ranked observational evidence is the next backend-first slice and should begin only when the user explicitly starts it.
+Phase 1 reliability foundation is complete. Phase 2 semantic metadata plumbing is implemented, and Gemini frontend integration is functionally in place. Phase 2.5 semantic frame completion is complete and verified on the backend and frontend. The opened Decisions workspace renders `decision_scope.segment_dimensions` as first-class decision-frame information. Phase 3 backend correction actions and ranked observational evidence are implemented and verified, and Gemini frontend rendering for Correction Results and Ranked Observational Evidence is complete as of May 22, 2026. The next active roadmap item is Phase 4: Canonical Active Dataset Contract.
 
 ## Documentation Areas
 
@@ -36,6 +38,7 @@ Phase 1 reliability foundation is complete. Phase 2 semantic metadata plumbing i
 | Codex harness | `project_docs/active/codex_harness_engineering.md` | Read for substantial Codex repo work before large source reads or noisy verification. |
 | Rules | `project_docs/active/rules/` | Read when ownership or frontend scope matters. |
 | Current council decision | `project_docs/active/agent_council/outputs/application-next-focus-priorities/` | Read when choosing next work. |
+| Emergency compounding-results council | `project_docs/active/agent_council/outputs/compounding-phase-results/` | Read when restructuring the roadmap around visible, compounding product outcomes. |
 | Contracts | `project_docs/active/contracts/` | Read when touching backend response shape, frontend consumption, or Gemini handoff. |
 | AI handoff | `project_docs/active/ai_hand_off/` | Active Codex/Gemini handoff records and ownership rules. |
 | Decision Intelligence docs | `project_docs/active/decision_intelligence/` | Do not bulk scan. Use `current/` for active docs and `completed/` only for reference. |
@@ -44,7 +47,7 @@ Phase 1 reliability foundation is complete. Phase 2 semantic metadata plumbing i
 
 ## Current Next Work
 
-There is no active Gemini implementation handoff right now. Phase 2.5 frontend segment rendering is complete, and its handoff remains as a completed record at `project_docs/active/ai_hand_off/phase_2_5_gemini_frontend_segment_dimensions.md`. The next implementation slice is Phase 3 at `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md`. Start it only when the user explicitly says to proceed.
+The Phase 3 Gemini frontend handoff at `project_docs/active/ai_hand_off/phase_3_gemini_frontend_correction_and_ranked_evidence.md` is complete. The active Phase 4 Gemini handoff is `project_docs/active/ai_hand_off/phase_4_gemini_frontend_canonical_active_dataset.md`.
 
 ## Do Not Scan By Default
 

--- a/project_docs/active/agent_council/README.md
+++ b/project_docs/active/agent_council/README.md
@@ -32,6 +32,8 @@ Current topic folders:
 
 `project_docs/active/agent_council/outputs/application-next-focus-priorities/`
 
+`project_docs/active/agent_council/outputs/compounding-phase-results/`
+
 ## Setup Summary
 
 The reusable setup now consists of an agent role definition, master council prompt, strict JSON schema, realistic sample output, usage documentation, output registry, and dependency-free validator. The framework is linked from `project_docs/INDEX.md` and `project_docs/active/status/decision_intelligence_execution_status.md`, and live outputs are stored under `project_docs/active/agent_council/outputs/`.
@@ -47,6 +49,12 @@ Before running the council, the orchestrating agent should inspect the current a
 Then paste `project_docs/active/agent_council/master_council_prompt.md` into the AI system that will simulate or coordinate the agents. Add the specific planning topic after the prompt in plain language. The council should run four rounds: independent proposals, critique, reconciliation, and final JSON synthesis.
 
 The output should be saved as JSON inside a topic folder. Use a topic slug and date-based filename inside `project_docs/active/agent_council/outputs/<topic-slug>/`. If the council creates an implementation handoff, save that handoff in the same topic folder.
+
+## Current Emergency Council Topic
+
+The active emergency topic is documented at `project_docs/active/agent_council/outputs/compounding-phase-results/README.md`.
+
+It asks the council to restructure the current Decision Intelligence roadmap around compounding, obvious product results because the current Codex/Gemini phase flow has produced too many microscopic outcomes that are hard for the user to see or trust.
 
 ## Good First Council Topic
 

--- a/project_docs/active/agent_council/outputs/README.md
+++ b/project_docs/active/agent_council/outputs/README.md
@@ -19,3 +19,5 @@ Current topics:
 `app-wide-ui-flaws/`
 
 `application-next-focus-priorities/`
+
+`compounding-phase-results/`

--- a/project_docs/active/agent_council/outputs/application-structure-decision-dashboard/2026-05-23-application-structure-decision-dashboard-council.json
+++ b/project_docs/active/agent_council/outputs/application-structure-decision-dashboard/2026-05-23-application-structure-decision-dashboard-council.json
@@ -1,0 +1,1189 @@
+{
+  "schema_version": "agent-council-output/v1",
+  "council_id": "application-structure-decision-dashboard-2026-05-23",
+  "generated_at": "2026-05-23T04:45:00Z",
+  "project_context": {
+    "project_name": "AI_Tool",
+    "current_workstream": "Decision Intelligence V3 application restructuring",
+    "planning_topic": "Create a clearer dashboard-style Decision Intelligence application structure with practical user-built decision assets.",
+    "context_summary": "The prior compounding-results council rejected a microscopic phase roadmap centered on hidden fields, readiness labels, repeated prompt text, and low-value internal structures. It recommended visible outcomes: Executive Decision Brief with Dataset Trust, Visual Evidence Board and Decision Map, bounded Scenario Compare, executive-ready exports, and Advanced Analysis Readiness Gates. This council converts that direction into an application structure. The product should remain a builder application, but its primary identity should become Decision Intelligence: users build decision briefs, decision maps, evidence boards, scenario comparisons, and exportable decision artifacts. Semantic concepts remain valid, but the app must communicate in a direct, down-to-earth business voice and make controls easy to adjust so the engine can rerun and update visible outcomes.",
+    "active_constraints": [
+      "Codex owns backend truth, contracts, tests, architecture, review, and project documentation.",
+      "Gemini owns frontend implementation unless the user explicitly authorizes Codex frontend edits in the current session.",
+      "The app must not imply fake simulation, optimization, causal proof, autonomous decisioning, predictions, or final recommendations.",
+      "Decision Map is the near-term safe framing; CDD or causal modeling must remain gated until assumptions, direction, validation, and confidence can be represented truthfully.",
+      "Every implementation unit must create an obvious user-visible result, not only backend fields, docs, or technical labels.",
+      "The application should help users build practical decision assets, not only inspect contract data."
+    ]
+  },
+  "sources_reviewed": [
+    {
+      "path": "project_docs/INDEX.md",
+      "source_type": "markdown",
+      "relevance": "Defines active routing and current documentation entry points.",
+      "reviewed_by": [
+        "architecture-guardian",
+        "implementation-planner"
+      ]
+    },
+    {
+      "path": "project_docs/active/README.md",
+      "source_type": "markdown",
+      "relevance": "Defines current project truth, scan rules, and active Phase 4 dataset-path routing that needs superseding.",
+      "reviewed_by": [
+        "architecture-guardian",
+        "product-ux-strategist",
+        "implementation-planner"
+      ]
+    },
+    {
+      "path": "project_docs/active/status/decision_intelligence_execution_status.md",
+      "source_type": "status",
+      "relevance": "Shows completed reliability, semantic, correction, ranked evidence, chat continuity, and frontend hardening work.",
+      "reviewed_by": [
+        "decision-intelligence-specialist",
+        "skeptic-qa-reviewer",
+        "data-ml-readiness-specialist"
+      ]
+    },
+    {
+      "path": "project_docs/active/rules/CODEX_FRONTEND_GUARDRAIL_READ_FIRST.md",
+      "source_type": "markdown",
+      "relevance": "Defines Codex and Gemini ownership split for backend/contracts/docs versus frontend implementation.",
+      "reviewed_by": [
+        "architecture-guardian",
+        "implementation-planner"
+      ]
+    },
+    {
+      "path": "project_docs/active/agent_council/outputs/compounding-phase-results/2026-05-23-emergency-compounding-council.json",
+      "source_type": "other",
+      "relevance": "Prior council result that recommended replacing microscopic phases with visible outcome units.",
+      "reviewed_by": [
+        "product-ux-strategist",
+        "decision-intelligence-specialist",
+        "implementation-planner"
+      ]
+    },
+    {
+      "path": "project_docs/active/reviews/project_pruning_recommendations.md",
+      "source_type": "markdown",
+      "relevance": "Identifies cleanup candidates, surfaces to demote or rewrite, and code areas that may overpromise recommendations, Autopilot, or AutoML.",
+      "reviewed_by": [
+        "skeptic-qa-reviewer",
+        "product-ux-strategist",
+        "architecture-guardian"
+      ]
+    },
+    {
+      "path": "project_docs/active/contracts/decision_objects.md",
+      "source_type": "contract",
+      "relevance": "Defines existing decision briefs, signals, scenarios, readiness, dataset summary, and ranked diagnostics that can support the new application structure.",
+      "reviewed_by": [
+        "architecture-guardian",
+        "decision-intelligence-specialist",
+        "data-ml-readiness-specialist"
+      ]
+    },
+    {
+      "path": "project_docs/active/agent_council/outputs/application-structure-decision-dashboard/README.md",
+      "source_type": "markdown",
+      "relevance": "Defines this council topic, Decision Map/CDD context, user direction, and output handling requirements.",
+      "reviewed_by": [
+        "product-ux-strategist",
+        "implementation-planner",
+        "skeptic-qa-reviewer"
+      ]
+    }
+  ],
+  "participating_agents": [
+    {
+      "agent_id": "architecture-guardian",
+      "role_name": "Architecture Guardian",
+      "perspective": "Protect backend-owned truth, honest capability boundaries, and a stable architecture for dashboard controls, Decision Map, scenarios, and exports.",
+      "decision_rights": "Can block frontend-only inference, fake causal claims, unsupported simulation, or hidden coupling between controls and analysis."
+    },
+    {
+      "agent_id": "product-ux-strategist",
+      "role_name": "Product/UX Strategist",
+      "perspective": "Make the app feel direct, practical, and valuable: fewer labels, clearer outcomes, dashboard controls, and exportable decision assets.",
+      "decision_rights": "Can reject structures that feel like contract viewers, generic analytics dashboards, or verbose internal diagnostics."
+    },
+    {
+      "agent_id": "decision-intelligence-specialist",
+      "role_name": "Decision Intelligence Specialist",
+      "perspective": "Preserve objectives, levers, outcomes, guardrails, scenarios, assumptions, evidence, and maps as the core intelligence model.",
+      "decision_rights": "Can require every surface to improve the decision workflow rather than generic app activity."
+    },
+    {
+      "agent_id": "data-ml-readiness-specialist",
+      "role_name": "Data/ML Readiness Specialist",
+      "perspective": "Keep dataset truth, ML readiness, scenario assumptions, validation boundaries, and causal limitations explicit but not dominant.",
+      "decision_rights": "Can gate CDD, Monte Carlo, prediction, and optimization until prerequisites are represented and validated."
+    },
+    {
+      "agent_id": "skeptic-qa-reviewer",
+      "role_name": "Skeptic/QA Reviewer",
+      "perspective": "Attack overpromising surfaces, unclear acceptance criteria, repeated labels, fake recommendations, and low-value exports.",
+      "decision_rights": "Can reject any structure whose visible result is not obvious, useful, truthful, and exportable where appropriate."
+    },
+    {
+      "agent_id": "implementation-planner",
+      "role_name": "Implementation Planner",
+      "perspective": "Sequence the restructure into Codex backend/docs tasks and Gemini frontend handoffs without broad rewrites or stale docs.",
+      "decision_rights": "Can decide implementation order, owner split, validation gates, and documentation changes."
+    }
+  ],
+  "conversation_rounds": {
+    "round_1_independent_proposals": [
+      {
+        "agent_id": "architecture-guardian",
+        "stance": "Build a dashboard around backend-owned decision state instead of frontend-inferred views.",
+        "claims": [
+          "The application should have one canonical decision workspace state that powers the brief, evidence board, scenario compare, Decision Map, and export.",
+          "Dashboard controls must submit explicit updates to backend-owned frame fields or scenario parameters before rerunning analysis.",
+          "CDD must remain gated until causal assumptions and validation can be represented."
+        ],
+        "challenged_assumptions": [
+          "A visual graph is not automatically a causal model.",
+          "A dashboard control should not mutate hidden frontend-only state if the backend result claims to update."
+        ],
+        "evidence": [
+          "The contracts already define decision workspaces, briefs, signals, scenarios, readiness, and ranked diagnostics.",
+          "The guardrail assigns backend truth and contracts to Codex and frontend implementation to Gemini."
+        ],
+        "proposed_changes": [
+          "Create a backend Decision Dashboard State contract that includes frame, dataset trust, evidence summary, scenario controls, map nodes, map edges, assumptions, and export sections.",
+          "Represent Decision Map edges as declared relationship, evidence association, constraint, segment, or unknown, not causal proof."
+        ],
+        "risks_flagged": [
+          "Frontend-only maps would drift from backend truth.",
+          "CDD terminology could overclaim causality."
+        ]
+      },
+      {
+        "agent_id": "product-ux-strategist",
+        "stance": "Make the main experience a decision dashboard that users can adjust and rerun.",
+        "claims": [
+          "The first Decision Intelligence screen should not be a chat transcript or contract inspector; it should be a dashboard with a short brief, key controls, evidence, map, scenario comparison, and export action.",
+          "The app should use business language first and technical language only when it clarifies a limitation or assumption.",
+          "More content is not more value; the brief should tell the user what moved, what matters, what to change, and what to export."
+        ],
+        "challenged_assumptions": [
+          "Semantic terminology should not dominate the UI.",
+          "Users should not need to understand implementation phases to use the product."
+        ],
+        "evidence": [
+          "The prior council identified label-heavy output as the core failure.",
+          "The pruning review identified recommendation, Autopilot, and AutoML language that may distract from the practical decision workflow."
+        ],
+        "proposed_changes": [
+          "Design the main surface as: Brief at top, Controls on the left, Evidence and Map in the center, Scenario Compare on the right or below, Export in the header.",
+          "Use short labels such as Goal, What You Can Change, Limits, Evidence, Scenarios, and Export instead of exposing internal terminology everywhere."
+        ],
+        "risks_flagged": [
+          "A dashboard can become cluttered if every internal field is surfaced.",
+          "Generic analytics widgets would dilute the Decision Intelligence identity."
+        ]
+      },
+      {
+        "agent_id": "decision-intelligence-specialist",
+        "stance": "Keep levers, outcomes, guardrails, and evidence, but make them active controls.",
+        "claims": [
+          "Levers and outcomes are strong concepts when they become things users can change, compare, and rerun.",
+          "The Decision Map should show the current decision model and evidence coverage so users can see what is known, assumed, or missing.",
+          "Scenario Compare should update from the same controls rather than being a separate feature island."
+        ],
+        "challenged_assumptions": [
+          "A brief without editable model controls will feel static.",
+          "A map without evidence and scenario hooks will feel decorative."
+        ],
+        "evidence": [
+          "Phase 3 ranked diagnostics and correction fields already create the basis for evidence and frame updates.",
+          "The existing scenario service can support bounded direct-adjustment comparisons."
+        ],
+        "proposed_changes": [
+          "Create decision-control groups for outcome, levers, guardrails, segments, assumptions, scenario inputs, and map relationships.",
+          "Rerun the engine after control changes and update brief, evidence, map, and scenario comparison together."
+        ],
+        "risks_flagged": [
+          "Changing controls without a clear rerun state can create stale or confusing results.",
+          "Scenario deltas can be mistaken for forecasts if labels are weak."
+        ]
+      },
+      {
+        "agent_id": "data-ml-readiness-specialist",
+        "stance": "Use readiness as a gate behind useful workflows, not the main result.",
+        "claims": [
+          "Dataset trust should be a compact status strip, not a full phase or dominant panel.",
+          "Advanced modeling should appear as locked or gated workflows with specific missing prerequisites.",
+          "CDD should start as declared relationships and observational evidence coverage, with causal mode unavailable until assumptions and validation exist."
+        ],
+        "challenged_assumptions": [
+          "Readiness labels are valuable only when tied to what a user can or cannot do next.",
+          "AutoML should not remain prominent in Decision Intelligence unless it is reframed as readiness-gated modeling."
+        ],
+        "evidence": [
+          "The contracts define dataset summaries and unsupported capability fields.",
+          "The pruning review flagged AutoML and prediction language as needing truthfulness review."
+        ],
+        "proposed_changes": [
+          "Add a Dataset Trust Strip with dataset name, source, rows, columns, transform state, and stale state.",
+          "Add an Advanced Gates drawer for prediction, Monte Carlo, optimization, and causal CDD prerequisites."
+        ],
+        "risks_flagged": [
+          "Advanced gates can become another label wall.",
+          "AutoML may conflict with the current observational boundary if surfaced carelessly."
+        ]
+      },
+      {
+        "agent_id": "skeptic-qa-reviewer",
+        "stance": "Demote anything that overpromises or produces generic output.",
+        "claims": [
+          "Legacy Strategic Recommendations should not remain visible as final-looking advice.",
+          "Autopilot should be hidden, renamed, or rewritten unless it produces a concrete decision asset.",
+          "AutoML and prediction surfaces should be gated outside the main Decision Intelligence flow until validation boundaries are obvious."
+        ],
+        "challenged_assumptions": [
+          "A feature is not worth keeping prominent because it exists.",
+          "A result is not good if it is long but not actionable."
+        ],
+        "evidence": [
+          "The pruning review named legacy recommendations, Autopilot, and AutoML as demote-or-rewrite candidates.",
+          "The prior council said no work is complete unless the visible result is obvious and export-worthy."
+        ],
+        "proposed_changes": [
+          "Replace Strategic Recommendations with Suggested Checks or Next Investigations.",
+          "Require acceptance screenshots or browser evidence for the main decision dashboard, not only build output.",
+          "Fail acceptance if the result is mostly labels, repeated prompt text, or internal capability boundaries."
+        ],
+        "risks_flagged": [
+          "Old surfaces can undermine the new product identity even if new surfaces are added.",
+          "Agents may keep low-value screens to avoid making hard product cuts."
+        ]
+      },
+      {
+        "agent_id": "implementation-planner",
+        "stance": "Sequence as a dashboard contract first, then Gemini layout, then pruning.",
+        "claims": [
+          "Codex should define a Decision Dashboard contract and docs before Gemini builds the new main surface.",
+          "Gemini should implement the visual structure from stable backend fields and route old surfaces behind the new flow.",
+          "Pruning should be staged: docs and artifacts first, overpromising language second, feature demotion third."
+        ],
+        "challenged_assumptions": [
+          "The app does not need a total rewrite to change its landscape.",
+          "The old Phase 4 handoff should not remain the default next implementation path."
+        ],
+        "evidence": [
+          "The active docs still route to Phase 4 canonical dataset work.",
+          "The new council prompt requires JSON saved to the topic folder and validated."
+        ],
+        "proposed_changes": [
+          "Outcome A: Decision Dashboard Contract.",
+          "Outcome B: Gemini Decision Dashboard Shell.",
+          "Outcome C: Decision Map and Evidence Board.",
+          "Outcome D: Bounded Scenario Controls.",
+          "Outcome E: Product-surface pruning and export polish."
+        ],
+        "risks_flagged": [
+          "Changing too many frontend surfaces at once would increase regression risk.",
+          "Docs must be updated quickly or the old roadmap will resume."
+        ]
+      }
+    ],
+    "round_2_critiques": [
+      {
+        "agent_id": "skeptic-qa-reviewer",
+        "stance": "The dashboard idea is strong only if old overpromising surfaces are actively demoted.",
+        "claims": [
+          "Adding a new dashboard while leaving Strategic Recommendations, Autopilot recommendations, and prediction-heavy AutoML prominent would create conflicting product truth.",
+          "The first acceptance test should be whether a user can change a lever or assumption and see the brief, evidence, map, and scenario state update without reading internal fields."
+        ],
+        "challenged_assumptions": [
+          "New structure alone fixes product confusion.",
+          "Old features can remain equally prominent without harming the new identity."
+        ],
+        "evidence": [
+          "Project pruning recommendations identified legacy recommendations, Autopilot, and AutoML as likely cleanup targets.",
+          "The prior council rejected low-value label-heavy results."
+        ],
+        "proposed_changes": [
+          "Make pruning a first-class recommendation, not an afterthought.",
+          "Require visible rerun/update behavior as an acceptance signal."
+        ],
+        "risks_flagged": [
+          "The app could become two products at once: a practical decision dashboard and an old generic AI toolbox."
+        ]
+      },
+      {
+        "agent_id": "architecture-guardian",
+        "stance": "The dashboard must be backed by a state contract, not ad hoc component state.",
+        "claims": [
+          "Controls, rerun state, stale markers, and export sections need backend-owned data or documented frontend-derived fields.",
+          "Decision Map nodes and edges need a typed contract before Gemini renders the editor."
+        ],
+        "challenged_assumptions": [
+          "Frontend can safely infer map relationships from arbitrary text.",
+          "Scenario controls can update projections without a backend recalculation contract."
+        ],
+        "evidence": [
+          "Decision object contracts already define several reusable pieces but not a unified dashboard state object.",
+          "Codex/Gemini guardrail requires backend truth before frontend implementation."
+        ],
+        "proposed_changes": [
+          "Add a DecisionDashboardState contract before frontend build.",
+          "Keep the first map generated and read-only or lightly editable until update semantics are stable."
+        ],
+        "risks_flagged": [
+          "Editable maps can create mismatched state if not persisted or rerun through backend."
+        ]
+      },
+      {
+        "agent_id": "product-ux-strategist",
+        "stance": "The language system must be part of the structure.",
+        "claims": [
+          "If labels stay academic, the dashboard will still feel like an internal model.",
+          "The user asked for direct, down-to-earth results that say what to do next."
+        ],
+        "challenged_assumptions": [
+          "A visual dashboard automatically improves clarity."
+        ],
+        "evidence": [
+          "The user explicitly said sometimes more is less and asked for direct results with technical phrases only when needed."
+        ],
+        "proposed_changes": [
+          "Define UI language pairs: objective becomes Goal, lever becomes Changeable Driver, guardrail becomes Limit, segment becomes Breakdown, readiness becomes Can Run / Needs Fix, recommendation becomes Next Check.",
+          "Keep technical terms available in details or tooltips."
+        ],
+        "risks_flagged": [
+          "Oversimplification could hide important truth boundaries if not paired with details."
+        ]
+      }
+    ],
+    "round_3_reconciliation": [
+      {
+        "agent_id": "implementation-planner",
+        "stance": "Resolved structure: one Decision Dashboard with four live zones and gated advanced modeling.",
+        "claims": [
+          "The main application structure should be a Decision Dashboard, not a scattered collection of chat, legacy recommendations, Autopilot, and ML panels.",
+          "The dashboard should have four live zones: Brief, Controls, Evidence/Map, and Scenarios/Export.",
+          "Old surfaces should be demoted or rewritten so they feed the dashboard rather than compete with it."
+        ],
+        "challenged_assumptions": [
+          "The old app shell can remain unchanged and still feel like a new product.",
+          "CDD should be the first label users see."
+        ],
+        "evidence": [
+          "The prior council created outcome units that map cleanly into dashboard zones.",
+          "The current app already has decision services, brief service, scenario service, ranked evidence, and export plumbing."
+        ],
+        "proposed_changes": [
+          "Codex defines DecisionDashboardState and DecisionMap contracts.",
+          "Gemini builds a decision dashboard shell after backend contracts stabilize.",
+          "Legacy recommendation and Autopilot language is rewritten or hidden behind lower-priority routes.",
+          "AutoML moves behind Advanced Gates until validation and prediction boundaries are clear."
+        ],
+        "risks_flagged": [
+          "The first implementation must be a narrow vertical slice, not a full application rewrite."
+        ]
+      },
+      {
+        "agent_id": "decision-intelligence-specialist",
+        "stance": "Resolved model: use Decision Map now and gated CDD later.",
+        "claims": [
+          "Decision Map should be the first visual model because it can be truthful with current capabilities.",
+          "CDD can become an advanced mode only when causal assumptions, direction, confidence, validation, and unsupported simulation boundaries are explicit."
+        ],
+        "challenged_assumptions": [
+          "CDD terminology is safe by default."
+        ],
+        "evidence": [
+          "Current contracts forbid causal claims and simulation.",
+          "The user wants visual decision models and dashboard-like control changes."
+        ],
+        "proposed_changes": [
+          "Map node types: Goal, Driver, Limit, Breakdown, Evidence, Assumption, Unknown, Dataset, Scenario.",
+          "Map edge types: declared relationship, observed association, constraint, breakdown, assumption, missing evidence."
+        ],
+        "risks_flagged": [
+          "Users may interpret relationship lines as causal effects without explicit edge labels."
+        ]
+      },
+      {
+        "agent_id": "product-ux-strategist",
+        "stance": "Resolved UX: direct brief first, controls second, details on demand.",
+        "claims": [
+          "The app should open with the answer artifact, not the machinery.",
+          "Users should be able to change drivers, limits, breakdowns, assumptions, and scenarios without hunting through forms."
+        ],
+        "challenged_assumptions": [
+          "Advanced terminology should remain visible everywhere."
+        ],
+        "evidence": [
+          "The user asked for one-of-a-kind, direct, to-the-point outputs."
+        ],
+        "proposed_changes": [
+          "Use a compact Executive Brief at the top with one clear summary, top quantified evidence, and next check.",
+          "Use dashboard controls with labels like Goal, Drivers, Limits, Breakdowns, Assumptions, Scenarios.",
+          "Put technical semantics in details panels and tooltips."
+        ],
+        "risks_flagged": [
+          "Too much simplification could reduce trust if details are unavailable."
+        ]
+      }
+    ],
+    "round_4_synthesis": [
+      {
+        "agent_id": "implementation-planner",
+        "stance": "Final synthesis: restructure AI_Tool into a Decision Intelligence builder dashboard.",
+        "claims": [
+          "The new application center should be a practical Decision Dashboard where users build and update decision assets.",
+          "The dashboard should produce a brief, evidence board, decision map, scenario comparison, and export from one coherent state.",
+          "Legacy recommendations, Autopilot, and AutoML should not remain prominent unless rewritten to support this flow truthfully."
+        ],
+        "challenged_assumptions": [
+          "The app should remain a generic AI toolbox with Decision Intelligence bolted on."
+        ],
+        "evidence": [
+          "The prior council, pruning review, and active contracts all support an outcome-based dashboard structure."
+        ],
+        "proposed_changes": [
+          "Adopt the resolved recommendations and suggested phases in this council output.",
+          "Update active docs and create Codex and Gemini handoffs after user acceptance."
+        ],
+        "risks_flagged": [
+          "Without doc updates, future work will drift back to the old Phase 4 path.",
+          "Without pruning, old surfaces will undermine the new direction."
+        ]
+      }
+    ]
+  },
+  "major_disagreements": [
+    {
+      "disagreement_id": "disagreement-decision-map-vs-cdd",
+      "topic": "Whether to present the visual model as CDD immediately",
+      "positions": [
+        {
+          "agent_id": "decision-intelligence-specialist",
+          "position": "Use Decision Map now and make CDD a later gated mode.",
+          "rationale": "Current capability supports declared relationships and observational evidence, not causal proof."
+        },
+        {
+          "agent_id": "product-ux-strategist",
+          "position": "Use user-friendly labels first.",
+          "rationale": "CDD may be too technical and may distract from the practical dashboard."
+        },
+        {
+          "agent_id": "data-ml-readiness-specialist",
+          "position": "Gate CDD behind assumptions, direction, confidence, and validation.",
+          "rationale": "Causal diagrams require stronger truth boundaries than current observational analysis."
+        }
+      ],
+      "status": "resolved",
+      "resolution": "The near-term product uses Decision Map. CDD becomes a gated advanced mode only after assumptions, causal direction, confidence, validation notes, and unsupported simulation boundaries are represented."
+    },
+    {
+      "disagreement_id": "disagreement-old-surfaces",
+      "topic": "Whether to preserve legacy recommendations, Autopilot, and AutoML as prominent app surfaces",
+      "positions": [
+        {
+          "agent_id": "skeptic-qa-reviewer",
+          "position": "Demote or rewrite them before they compete with the new dashboard.",
+          "rationale": "They overpromise and create low-value or generic output risk."
+        },
+        {
+          "agent_id": "architecture-guardian",
+          "position": "Do not delete useful services blindly.",
+          "rationale": "Some services can be reused if contracts and labels are corrected."
+        },
+        {
+          "agent_id": "implementation-planner",
+          "position": "Stage demotion and rewrite after the dashboard contract exists.",
+          "rationale": "Controlled pruning avoids breaking working features before replacements exist."
+        }
+      ],
+      "status": "resolved",
+      "resolution": "Keep reusable code temporarily, but demote prominent UI and rewrite language. Legacy recommendations become Next Checks or Suggested Investigations. AutoML moves behind Advanced Gates. Autopilot must produce a decision asset or be hidden from the main flow."
+    },
+    {
+      "disagreement_id": "disagreement-dashboard-scope",
+      "topic": "How much of the application should be restructured at once",
+      "positions": [
+        {
+          "agent_id": "product-ux-strategist",
+          "position": "The main experience must change visibly.",
+          "rationale": "The user is changing the project landscape and needs a product-level shift."
+        },
+        {
+          "agent_id": "implementation-planner",
+          "position": "Start with a thin vertical Decision Dashboard slice.",
+          "rationale": "A full app rewrite would be risky and slow."
+        },
+        {
+          "agent_id": "architecture-guardian",
+          "position": "Backend state contract first.",
+          "rationale": "The dashboard must not become disconnected frontend presentation."
+        }
+      ],
+      "status": "resolved",
+      "resolution": "Implement a narrow but visible Decision Dashboard vertical slice first: brief, controls, dataset trust, evidence summary, decision map preview, scenario placeholder or bounded preview, and export structure from one backend state."
+    }
+  ],
+  "resolved_recommendations": [
+    {
+      "recommendation_id": "rec-main-decision-dashboard",
+      "title": "Make Decision Dashboard the primary application structure",
+      "summary": "Recenter the app around a dashboard where users build, adjust, rerun, and export decision assets. The dashboard should unify brief, controls, evidence, map, scenarios, dataset trust, and export from one coherent decision state.",
+      "originating_agents": [
+        "product-ux-strategist",
+        "decision-intelligence-specialist",
+        "implementation-planner"
+      ],
+      "source_paths": [
+        "project_docs/active/agent_council/outputs/compounding-phase-results/2026-05-23-emergency-compounding-council.json",
+        "project_docs/active/agent_council/outputs/application-structure-decision-dashboard/README.md",
+        "project_docs/active/contracts/decision_objects.md"
+      ],
+      "priority": "critical",
+      "confidence": 0.92,
+      "implementation_timing": "now",
+      "rationale": "The user wants an application that helps people build practical decision assets. A dashboard gives users direct controls and visible results instead of a chain of hidden phases and label-heavy artifacts.",
+      "impacted_areas": [
+        "decision workspace backend",
+        "decision contracts",
+        "AI Chat to Decisions handoff",
+        "DecisionPanel and DecisionWorkspaceView",
+        "export pipeline",
+        "active docs"
+      ],
+      "frontend_implications": [
+        "Gemini should build a main Decision Dashboard shell after Codex defines the contract.",
+        "The visible layout should prioritize brief, controls, evidence/map, scenarios, and export.",
+        "Old surfaces should route into the dashboard or be demoted."
+      ],
+      "backend_implications": [
+        "Codex should define a DecisionDashboardState payload composed from existing decision workspace, ranked diagnostics, brief, dataset trust, scenario preview, and map elements.",
+        "Backend should track stale state after control changes."
+      ],
+      "contract_considerations": [
+        "Use additive fields and existing contracts where possible.",
+        "Define dashboard sections and update semantics before frontend implementation."
+      ],
+      "testing_considerations": [
+        "Test that a complete decision prompt produces a dashboard-ready state.",
+        "Test that a control update changes stale state and rerun output.",
+        "Test unsupported simulation and final recommendation requests remain bounded."
+      ],
+      "risks": [
+        "The dashboard could become cluttered if every internal field is rendered.",
+        "A frontend-only dashboard would drift from backend truth."
+      ],
+      "dependencies": [
+        "Codex dashboard contract",
+        "User approval to supersede old Phase 4 next path"
+      ],
+      "acceptance_signals": [
+        "A user can open one Decision Intelligence surface and see the brief, controls, evidence, map, scenarios, dataset trust, and export affordance.",
+        "The result is direct, concise, and not dominated by readiness labels.",
+        "Changing a control makes the result visibly stale or reruns the engine."
+      ]
+    },
+    {
+      "recommendation_id": "rec-dashboard-control-model",
+      "title": "Create dashboard controls for goals, drivers, limits, breakdowns, assumptions, and scenarios",
+      "summary": "Turn semantic concepts into practical controls. Users should be able to change the goal, drivers, limits, breakdowns, assumptions, filters, and scenario inputs, then rerun the engine and see results update.",
+      "originating_agents": [
+        "decision-intelligence-specialist",
+        "product-ux-strategist",
+        "architecture-guardian"
+      ],
+      "source_paths": [
+        "project_docs/active/status/decision_intelligence_execution_status.md",
+        "project_docs/active/contracts/decision_objects.md",
+        "project_docs/active/agent_council/outputs/application-structure-decision-dashboard/README.md"
+      ],
+      "priority": "critical",
+      "confidence": 0.89,
+      "implementation_timing": "now",
+      "rationale": "Levers, outcomes, guardrails, and segments are valuable only when users can manipulate them and see the engine update. Controls make the app a builder rather than a report viewer.",
+      "impacted_areas": [
+        "decision workspace correction actions",
+        "scenario service",
+        "decision dashboard contract",
+        "Gemini dashboard controls"
+      ],
+      "frontend_implications": [
+        "Gemini should use dashboard controls with plain labels: Goal, Drivers, Limits, Breakdowns, Assumptions, Scenarios.",
+        "Technical semantics should appear in details or tooltips.",
+        "Controls should show stale/rerun state clearly."
+      ],
+      "backend_implications": [
+        "Codex should map controls to explicit backend correction or update actions.",
+        "Backend should recompute readiness, evidence, map, and scenario preview after accepted changes."
+      ],
+      "contract_considerations": [
+        "Define control IDs, target paths, accepted value types, stale flags, and rerun requirements.",
+        "Do not allow arbitrary frontend mutation of workspace state."
+      ],
+      "testing_considerations": [
+        "Test updating objective, lever, guardrail threshold, segment, and scenario adjustment.",
+        "Test that stale state is visible before rerun.",
+        "Test invalid updates produce useful blockers."
+      ],
+      "risks": [
+        "Controls can create false precision if scenario assumptions are unclear.",
+        "Too many controls at once can overwhelm users."
+      ],
+      "dependencies": [
+        "DecisionDashboardState contract",
+        "Existing correction loop"
+      ],
+      "acceptance_signals": [
+        "A user can change at least one driver or limit and see the dashboard update path.",
+        "The UI uses business labels first and preserves technical detail on demand.",
+        "The backend owns the accepted change and rerun state."
+      ]
+    },
+    {
+      "recommendation_id": "rec-decision-map-now-cdd-later",
+      "title": "Use Decision Map now and gate CDD as an advanced mode",
+      "summary": "Introduce a Decision Map that shows declared relationships and observational evidence coverage. Defer CDD as a causal model until assumptions, direction, confidence, validation, and unsupported simulation boundaries can be represented.",
+      "originating_agents": [
+        "decision-intelligence-specialist",
+        "data-ml-readiness-specialist",
+        "architecture-guardian"
+      ],
+      "source_paths": [
+        "project_docs/active/agent_council/outputs/application-structure-decision-dashboard/README.md",
+        "project_docs/active/contracts/decision_objects.md"
+      ],
+      "priority": "high",
+      "confidence": 0.9,
+      "implementation_timing": "now",
+      "rationale": "The user wants CDD-like visual models, but current product truth supports declared decision relationships and observational evidence, not causal proof. Decision Map gives visual value now without overclaiming.",
+      "impacted_areas": [
+        "decision map contract",
+        "DecisionWorkspaceView",
+        "frontend graph or canvas component",
+        "export mapping"
+      ],
+      "frontend_implications": [
+        "Gemini should render a map with nodes for Goal, Driver, Limit, Breakdown, Evidence, Assumption, Unknown, Dataset, and Scenario.",
+        "Edges should be labeled as declared relationship, observed association, constraint, breakdown, assumption, or missing evidence.",
+        "The UI should not call the map causal unless the advanced CDD gate is satisfied."
+      ],
+      "backend_implications": [
+        "Codex should generate typed map nodes and edges from workspace state, semantic bindings, ranked diagnostics, and assumptions.",
+        "Backend should include map limitations and evidence coverage."
+      ],
+      "contract_considerations": [
+        "Define map node and edge schemas.",
+        "Include relationship_type, confidence where available, source references, and truth_boundary.",
+        "Reserve causal fields for future gated CDD."
+      ],
+      "testing_considerations": [
+        "Test map generation for a complete decision frame.",
+        "Test missing evidence nodes for incomplete semantic coverage.",
+        "Test that no causal labels appear in default map output."
+      ],
+      "risks": [
+        "Users may interpret lines as causal effects.",
+        "A decorative map without controls or evidence would add little value."
+      ],
+      "dependencies": [
+        "DecisionDashboardState contract",
+        "Ranked diagnostics and semantic coverage"
+      ],
+      "acceptance_signals": [
+        "The map helps users understand the current decision model at a glance.",
+        "Every edge has a truthful relationship label.",
+        "CDD or causal mode remains gated."
+      ]
+    },
+    {
+      "recommendation_id": "rec-direct-business-language",
+      "title": "Adopt direct business language with technical details on demand",
+      "summary": "Translate internal terms into practical UI language: objective becomes Goal, lever becomes Driver or What You Can Change, guardrail becomes Limit, segment becomes Breakdown, recommendation becomes Next Check, readiness becomes Can Run or Needs Fix.",
+      "originating_agents": [
+        "product-ux-strategist",
+        "skeptic-qa-reviewer"
+      ],
+      "source_paths": [
+        "project_docs/active/agent_council/outputs/application-structure-decision-dashboard/README.md",
+        "project_docs/active/reviews/project_pruning_recommendations.md"
+      ],
+      "priority": "high",
+      "confidence": 0.88,
+      "implementation_timing": "now",
+      "rationale": "The user explicitly asked for one-of-a-kind, direct, down-to-earth outputs where sometimes more is less. The app should not feel like a semantic contract viewer.",
+      "impacted_areas": [
+        "frontend copy",
+        "decision dashboard labels",
+        "exports",
+        "status and handoff docs"
+      ],
+      "frontend_implications": [
+        "Gemini should use plain business labels and place technical terms in tooltips or details panels.",
+        "Exports should use concise executive language."
+      ],
+      "backend_implications": [
+        "Codex should provide display labels and concise summaries instead of forcing frontend to summarize raw fields.",
+        "Backend should keep technical fields for traceability."
+      ],
+      "contract_considerations": [
+        "Add display_label or display_sections only where existing labels are too internal.",
+        "Keep canonical field names stable for contracts."
+      ],
+      "testing_considerations": [
+        "Review output for repeated prompt text, label walls, and over-technical summaries.",
+        "Acceptance should fail if the result does not clearly tell the user what to inspect, change, compare, or export."
+      ],
+      "risks": [
+        "Oversimplification may hide important limitations if details are unavailable."
+      ],
+      "dependencies": [
+        "Decision dashboard design",
+        "Export structure"
+      ],
+      "acceptance_signals": [
+        "A non-technical user can understand the result without reading schema terms.",
+        "Technical terms remain available when needed.",
+        "The brief is concise and action-oriented without pretending to make the final decision."
+      ]
+    },
+    {
+      "recommendation_id": "rec-prune-overpromising-surfaces",
+      "title": "Demote or rewrite overpromising legacy surfaces",
+      "summary": "Legacy Strategic Recommendations, Autopilot recommendation flows, AutoML prediction surfaces, and generic workflow nodes should not remain prominent in the main Decision Intelligence path unless rewritten to support the dashboard truthfully.",
+      "originating_agents": [
+        "skeptic-qa-reviewer",
+        "product-ux-strategist",
+        "implementation-planner"
+      ],
+      "source_paths": [
+        "project_docs/active/reviews/project_pruning_recommendations.md",
+        "project_docs/active/status/decision_intelligence_execution_status.md"
+      ],
+      "priority": "high",
+      "confidence": 0.86,
+      "implementation_timing": "next",
+      "rationale": "Old surfaces can undermine the new product even if they are technically functional. Anything that overpromises recommendations, predictions, or autopilot behavior must be hidden, gated, or rewritten.",
+      "impacted_areas": [
+        "DecisionRecommendations.jsx",
+        "DecisionWorkspaceView.jsx",
+        "backend/routes/autopilot.py",
+        "AiAutopilot.jsx",
+        "AutoMLPanel.jsx",
+        "MachineLearningPanel.jsx",
+        "workflow command labels"
+      ],
+      "frontend_implications": [
+        "Gemini should rename Strategic Recommendations to Next Checks or Suggested Investigations if kept.",
+        "Autopilot should not be a primary Decision Intelligence action unless it creates a concrete decision asset.",
+        "AutoML should move behind Advanced Gates."
+      ],
+      "backend_implications": [
+        "Codex should review endpoint labels and response summaries for overclaiming.",
+        "Backend may keep services but should expose gated states and truthful labels."
+      ],
+      "contract_considerations": [
+        "Do not delete contracts that can be reused by brief, scenario, or evidence workflows.",
+        "Deprecate or alias recommendation language where needed."
+      ],
+      "testing_considerations": [
+        "Search for recommendation, prediction, forecast, optimization, and autopilot language after rewrite.",
+        "Verify main Decision Intelligence flow does not expose unsupported claims."
+      ],
+      "risks": [
+        "Removing surfaces too early could break existing navigation.",
+        "Leaving them prominent could confuse users about product capability."
+      ],
+      "dependencies": [
+        "Decision Dashboard replacement path",
+        "User approval for frontend demotion work or Gemini handoff"
+      ],
+      "acceptance_signals": [
+        "Main Decision Intelligence UI no longer leads with final-sounding recommendations.",
+        "Autopilot and AutoML are gated, rewritten, or out of the primary path.",
+        "Old services that remain have truthful labels and clear boundaries."
+      ]
+    },
+    {
+      "recommendation_id": "rec-export-decision-assets",
+      "title": "Export decision assets, not raw internal reports",
+      "summary": "Exports should package the brief, dataset trust, top evidence, Decision Map, scenario comparison, assumptions, and caveats into an executive-ready decision asset.",
+      "originating_agents": [
+        "product-ux-strategist",
+        "skeptic-qa-reviewer",
+        "decision-intelligence-specialist"
+      ],
+      "source_paths": [
+        "project_docs/active/agent_council/outputs/compounding-phase-results/2026-05-23-emergency-compounding-council.json",
+        "project_docs/active/contracts/decision_objects.md"
+      ],
+      "priority": "high",
+      "confidence": 0.84,
+      "implementation_timing": "next",
+      "rationale": "The prior exported result failed because it was not share-worthy. The new app structure must make export a first-class product proof.",
+      "impacted_areas": [
+        "decision PDF export",
+        "AIReporter",
+        "DecisionWorkspaceView",
+        "DecisionDashboardState export sections"
+      ],
+      "frontend_implications": [
+        "Gemini should expose export from the dashboard header or brief area.",
+        "Export preview should match the dashboard hierarchy."
+      ],
+      "backend_implications": [
+        "Codex should provide export-ready sections with concise titles, summaries, evidence, map, scenarios, assumptions, and caveats.",
+        "Backend should avoid forcing PDF code to synthesize raw internals."
+      ],
+      "contract_considerations": [
+        "Add export_sections if needed.",
+        "Ensure export uses the same truth boundary and dataset trust as the dashboard."
+      ],
+      "testing_considerations": [
+        "Verify exported artifact includes quantified evidence and a map or scenario summary when available.",
+        "Reject exports that contain mostly labels, repeated prompt text, or raw guardrails."
+      ],
+      "risks": [
+        "Export work can become polish-heavy unless backed by concise backend sections."
+      ],
+      "dependencies": [
+        "Decision Dashboard contract",
+        "Existing procedural PDF export pipeline"
+      ],
+      "acceptance_signals": [
+        "A user can export a decision asset that stands alone.",
+        "The export tells a concise decision story and includes caveats.",
+        "The export avoids fake final recommendations."
+      ]
+    }
+  ],
+  "unresolved_questions": [
+    {
+      "question_id": "question-dashboard-entry-point",
+      "question": "Should AI Chat remain the primary entry into Decision Dashboard, or should Decisions open directly to the dashboard with chat as an assistive side panel?",
+      "owner": "User with Codex product architecture",
+      "needed_before": "Gemini dashboard shell handoff",
+      "impact": "Determines navigation, first-screen structure, and whether chat is the front door or a supporting tool."
+    },
+    {
+      "question_id": "question-map-editing-depth",
+      "question": "Should the first Decision Map be read-only/generated, lightly editable, or fully editable?",
+      "owner": "Codex",
+      "needed_before": "Decision Map contract and frontend handoff",
+      "impact": "Determines persistence, correction actions, rerun behavior, and frontend complexity."
+    },
+    {
+      "question_id": "question-autopilot-future",
+      "question": "Should Autopilot be removed from the main product, renamed into a decision asset generator, or gated as an advanced workflow builder?",
+      "owner": "User with Codex review",
+      "needed_before": "Product surface pruning implementation",
+      "impact": "Affects whether the app remains a broad AI toolbox or becomes tightly focused on Decision Intelligence."
+    },
+    {
+      "question_id": "question-automl-positioning",
+      "question": "Should AutoML remain in the app as a separate builder tool, or be hidden behind Decision Intelligence Advanced Gates?",
+      "owner": "User with Data/ML Readiness review",
+      "needed_before": "Advanced Gates implementation",
+      "impact": "Affects capability boundaries and whether prediction-heavy functionality distracts from observational Decision Intelligence."
+    }
+  ],
+  "risks": [
+    {
+      "risk_id": "risk-dashboard-contract-gap",
+      "title": "Dashboard UI is built before backend state contract exists",
+      "severity": "high",
+      "likelihood": "medium",
+      "mitigation": "Codex defines DecisionDashboardState, controls, map, stale state, and export sections before Gemini frontend implementation.",
+      "owner": "Codex"
+    },
+    {
+      "risk_id": "risk-cdd-overclaim",
+      "title": "Decision Map is interpreted as causal CDD",
+      "severity": "high",
+      "likelihood": "medium",
+      "mitigation": "Use Decision Map label by default, type all edges, and gate causal CDD behind explicit assumptions and validation fields.",
+      "owner": "Data/ML Readiness Specialist"
+    },
+    {
+      "risk_id": "risk-old-ui-conflict",
+      "title": "Old recommendation, Autopilot, and AutoML surfaces undermine the new product identity",
+      "severity": "high",
+      "likelihood": "high",
+      "mitigation": "Demote, rewrite, or gate these surfaces after the dashboard path exists; update labels immediately where they overpromise.",
+      "owner": "Skeptic/QA Reviewer"
+    },
+    {
+      "risk_id": "risk-dashboard-clutter",
+      "title": "Decision Dashboard becomes another wall of labels",
+      "severity": "medium",
+      "likelihood": "medium",
+      "mitigation": "Brief first, controls second, details on demand. Acceptance fails if the result is not concise and useful.",
+      "owner": "Product/UX Strategist"
+    },
+    {
+      "risk_id": "risk-stale-results",
+      "title": "Users change controls but results do not clearly rerun or mark stale state",
+      "severity": "high",
+      "likelihood": "medium",
+      "mitigation": "Add stale markers and rerun contract semantics for all dashboard controls.",
+      "owner": "Architecture Guardian"
+    }
+  ],
+  "impacted_codebase_areas": [
+    {
+      "area": "Decision dashboard backend contract",
+      "path_patterns": [
+        "backend/services/decision_workspace_service.py",
+        "backend/decision_engine/chat_service.py",
+        "project_docs/active/contracts/decision_objects.md",
+        "tests/test_decision_*.py"
+      ],
+      "why_it_matters": "The dashboard must be powered by backend-owned state, not frontend inference.",
+      "change_type": "backend"
+    },
+    {
+      "area": "Decision frontend main surface",
+      "path_patterns": [
+        "frontend/frontend/src/features/business/decision/DecisionPanel.jsx",
+        "frontend/frontend/src/features/business/decision/DecisionWorkspaceView.jsx",
+        "frontend/frontend/src/features/ai/AIShell.jsx"
+      ],
+      "why_it_matters": "Gemini will need to build the Decision Dashboard shell and route existing decision state into it.",
+      "change_type": "frontend"
+    },
+    {
+      "area": "Decision Map and visual model",
+      "path_patterns": [
+        "frontend/frontend/src/features/business/decision/*",
+        "backend/services/decision_workspace_service.py",
+        "project_docs/active/contracts/decision_objects.md"
+      ],
+      "why_it_matters": "The app needs a first-class visual model for declared relationships and evidence coverage.",
+      "change_type": "contract"
+    },
+    {
+      "area": "Scenario comparison",
+      "path_patterns": [
+        "backend/services/scenario_service.py",
+        "frontend/frontend/src/features/business/decision/ScenarioPreview.jsx",
+        "project_docs/active/contracts/decision_objects.md"
+      ],
+      "why_it_matters": "Scenario controls should be integrated into the dashboard as bounded sensitivity analysis.",
+      "change_type": "backend"
+    },
+    {
+      "area": "Overpromising legacy surfaces",
+      "path_patterns": [
+        "frontend/frontend/src/features/business/decision/DecisionRecommendations.jsx",
+        "backend/services/recommendation_service.py",
+        "backend/routes/autopilot.py",
+        "frontend/frontend/src/features/ai/AiAutopilot.jsx",
+        "frontend/frontend/src/components/data_management/AutoMLPanel.jsx",
+        "frontend/frontend/src/features/machine_learning/MachineLearningPanel.jsx"
+      ],
+      "why_it_matters": "These surfaces may conflict with the new direct, truthful Decision Intelligence structure.",
+      "change_type": "frontend"
+    },
+    {
+      "area": "Active project docs and handoffs",
+      "path_patterns": [
+        "project_docs/INDEX.md",
+        "project_docs/active/README.md",
+        "project_docs/active/status/decision_intelligence_execution_status.md",
+        "project_docs/active/ai_hand_off/*.md",
+        "project_docs/active/decision_intelligence/current/*.md"
+      ],
+      "why_it_matters": "Docs still route to the old Phase 4 path and must be updated before implementation.",
+      "change_type": "documentation"
+    }
+  ],
+  "frontend_implications": [
+    "Gemini should build a new Decision Dashboard shell only after Codex defines the backend contract.",
+    "The dashboard should prioritize Brief, Controls, Evidence/Decision Map, Scenario Compare, Dataset Trust, and Export.",
+    "UI labels should be direct and business-facing, with technical terms in details or tooltips.",
+    "Legacy Strategic Recommendations should be renamed, demoted, or removed from the main flow.",
+    "Autopilot and AutoML should not remain primary Decision Intelligence surfaces unless they are rewritten or gated.",
+    "Frontend acceptance requires a visible path where changing a driver, limit, or assumption updates stale/rerun state and visible outcomes."
+  ],
+  "backend_implications": [
+    "Codex should define DecisionDashboardState as the main contract for the new structure.",
+    "Codex should define DecisionMap node and edge schemas with non-causal defaults.",
+    "Dashboard controls should map to explicit correction, update, or scenario actions.",
+    "Backend should produce concise brief and export sections so frontend does not summarize raw internals.",
+    "Scenario Compare should remain direct-adjustment sensitivity analysis unless future prerequisites unlock stronger modeling.",
+    "Unsupported advanced capabilities must remain gated and truthful."
+  ],
+  "contract_considerations": [
+    "Additive contracts should reuse existing DecisionBrief, DecisionSignal, Scenario, DecisionScenarioPreview, Dataset Summary, readiness, capability_state, and ranked_diagnostics where possible.",
+    "DecisionDashboardState should include frame summary, dataset trust, executive brief, control model, evidence summary, decision map, scenario preview, advanced gates, stale state, and export sections.",
+    "DecisionMap nodes should include node_id, node_type, label, summary, source_path or source_ref, confidence where available, and status.",
+    "DecisionMap edges should include edge_id, source_node_id, target_node_id, relationship_type, label, evidence_refs, assumptions, limitations, and causal_status.",
+    "CDD fields should be reserved or gated until causal assumptions, direction, confidence, and validation can be truthfully represented.",
+    "Display labels should be added where useful without renaming canonical contract fields."
+  ],
+  "testing_considerations": [
+    "Backend tests should verify dashboard state generation for complete, incomplete, corrected, and unsupported prompts.",
+    "Control update tests should verify stale state and rerun semantics.",
+    "Decision Map tests should verify non-causal edge labels and missing-evidence handling.",
+    "Scenario tests should verify direct-adjustment deltas, assumptions, and guardrail impact without forecast or optimization claims.",
+    "Frontend acceptance should include one focused browser flow for changing a control and observing updated brief, evidence, map, or scenario state.",
+    "Copy review should reject label-heavy, generic, or overpromising results.",
+    "Export verification should confirm a concise decision asset rather than raw internal output."
+  ],
+  "implementation_priority": {
+    "top_priority_ids": [
+      "rec-main-decision-dashboard",
+      "rec-dashboard-control-model",
+      "rec-decision-map-now-cdd-later",
+      "rec-direct-business-language"
+    ],
+    "deferred_ids": [
+      "rec-prune-overpromising-surfaces",
+      "rec-export-decision-assets"
+    ],
+    "rationale": "The immediate structure needs a backend-owned dashboard state, practical controls, Decision Map, and direct language. Pruning and export are high value but should follow once the replacement path is clear enough to avoid breaking the product without a destination."
+  },
+  "suggested_implementation_phases": [
+    {
+      "phase_id": "phase-0-doc-reset",
+      "title": "Documentation Reset For Decision Dashboard",
+      "owner": "Codex",
+      "objective": "Update active docs so the old Phase 4 dataset-contract path is superseded by the Decision Dashboard structure.",
+      "recommendation_ids": [
+        "rec-main-decision-dashboard"
+      ],
+      "entry_criteria": [
+        "User accepts this council direction.",
+        "Application structure council JSON is validated and saved."
+      ],
+      "exit_criteria": [
+        "Active docs route future agents to Decision Dashboard contract work.",
+        "Old Phase 4 handoff is marked superseded, paused, or narrowed into Dataset Trust.",
+        "Codex/Gemini ownership remains explicit."
+      ],
+      "validation_plan": [
+        "Read INDEX, active README, status, and handoff README after edits.",
+        "Confirm no active-next instruction tells Gemini to start broad Phase 4 dataset alignment unchanged."
+      ]
+    },
+    {
+      "phase_id": "phase-1-dashboard-contract",
+      "title": "Decision Dashboard State Contract",
+      "owner": "Codex",
+      "objective": "Define the backend-owned state that powers brief, controls, dataset trust, evidence, map, scenarios, gates, and export.",
+      "recommendation_ids": [
+        "rec-main-decision-dashboard",
+        "rec-dashboard-control-model",
+        "rec-direct-business-language"
+      ],
+      "entry_criteria": [
+        "Docs are reset to the new structure.",
+        "Existing decision workspace, ranked diagnostics, brief, and scenario services are inspected."
+      ],
+      "exit_criteria": [
+        "DecisionDashboardState contract is documented.",
+        "Backend can produce dashboard-ready state for at least one complete prompt.",
+        "Control update and stale/rerun semantics are defined."
+      ],
+      "validation_plan": [
+        "Run focused backend tests for dashboard state generation.",
+        "Verify unsupported capabilities remain truthful.",
+        "Review payload for concise display labels and absence of raw label walls."
+      ]
+    },
+    {
+      "phase_id": "phase-2-decision-map-contract",
+      "title": "Decision Map Contract And Generated Preview",
+      "owner": "Codex",
+      "objective": "Create typed non-causal Decision Map nodes and edges from the decision workspace and evidence coverage.",
+      "recommendation_ids": [
+        "rec-decision-map-now-cdd-later"
+      ],
+      "entry_criteria": [
+        "DecisionDashboardState exists or is drafted.",
+        "Workspace frame and ranked diagnostics provide enough source data for map generation."
+      ],
+      "exit_criteria": [
+        "DecisionMap node and edge schema is documented.",
+        "Backend produces generated map preview with typed non-causal relationships.",
+        "CDD advanced mode remains gated."
+      ],
+      "validation_plan": [
+        "Test generated map for complete and incomplete decision frames.",
+        "Verify all edges have truthful relationship types.",
+        "Search output for unsupported causal claims."
+      ]
+    },
+    {
+      "phase_id": "phase-3-gemini-dashboard-handoff",
+      "title": "Gemini Decision Dashboard Frontend Handoff",
+      "owner": "Codex writes handoff, Gemini implements frontend",
+      "objective": "Give Gemini a focused frontend task to render the dashboard shell from backend-owned state.",
+      "recommendation_ids": [
+        "rec-main-decision-dashboard",
+        "rec-dashboard-control-model",
+        "rec-decision-map-now-cdd-later",
+        "rec-direct-business-language"
+      ],
+      "entry_criteria": [
+        "Dashboard and map contracts are stable enough for frontend rendering.",
+        "Codex has verified backend payloads with focused tests."
+      ],
+      "exit_criteria": [
+        "Gemini handoff names files, visible structure, controls, map behavior, language rules, acceptance prompts, and export expectations.",
+        "Frontend implementation shows concise brief, controls, dataset trust, evidence, decision map, scenarios, and export affordance where available."
+      ],
+      "validation_plan": [
+        "Gemini runs build and one browser flow.",
+        "Codex review confirms frontend does not infer unsupported backend truth.",
+        "User-visible result is obvious and direct."
+      ]
+    },
+    {
+      "phase_id": "phase-4-prune-and-export",
+      "title": "Product Surface Pruning And Decision Asset Export",
+      "owner": "Codex coordinates, Gemini implements frontend changes",
+      "objective": "Demote or rewrite overpromising old surfaces and make export a first-class decision asset.",
+      "recommendation_ids": [
+        "rec-prune-overpromising-surfaces",
+        "rec-export-decision-assets"
+      ],
+      "entry_criteria": [
+        "Decision Dashboard path exists.",
+        "User approves demotion or rewrite of old surfaces."
+      ],
+      "exit_criteria": [
+        "Legacy recommendations, Autopilot, and AutoML no longer compete with the main Decision Intelligence flow.",
+        "Export produces a concise decision asset with brief, evidence, map, scenarios, assumptions, and caveats where available."
+      ],
+      "validation_plan": [
+        "Search UI copy for overpromising recommendation, prediction, forecast, optimization, and autopilot claims.",
+        "Run focused browser/export flow.",
+        "Inspect export for concise, truthful, share-worthy content."
+      ]
+    }
+  ],
+  "final_synthesis_summary": {
+    "executive_summary": "The council recommends changing AI_Tool from a generic AI toolbox with Decision Intelligence pieces into a practical Decision Intelligence builder dashboard. The main experience should let users build and update decision assets: a concise Executive Brief, dashboard controls for goals/drivers/limits/breakdowns/assumptions/scenarios, Dataset Trust, Evidence Board, Decision Map, bounded Scenario Compare, Advanced Gates, and export. Semantic concepts remain valid, but they should be translated into direct business language and made actionable through controls. Decision Map should ship before CDD; causal CDD remains gated until assumptions, direction, confidence, and validation can be represented truthfully.",
+    "strongest_proposal": "Build a backend-owned DecisionDashboardState and use it to power a Gemini-rendered Decision Dashboard where users can change a driver, limit, assumption, breakdown, or scenario and see the brief, evidence, map, scenario, and export state update.",
+    "main_tradeoff": "The project must visibly change its product identity without overclaiming. That means moving quickly toward dashboard controls and visual models, while keeping CDD, Monte Carlo, prediction, optimization, and final recommendations gated until the backend can support them honestly.",
+    "decision_for_next_agent": "Do not start a broad frontend redesign or old Phase 4 dataset alignment. First update active docs, then have Codex define DecisionDashboardState and DecisionMap contracts. After backend payloads are verified, write a focused Gemini handoff for the Decision Dashboard shell.",
+    "non_goals": [
+      "Do not ship CDD as causal proof in the near term.",
+      "Do not imply Monte Carlo simulation, optimization, prediction, autonomous decisioning, or final recommendations.",
+      "Do not leave old recommendation and Autopilot surfaces prominent if they conflict with the new direction.",
+      "Do not build a frontend-only dashboard that invents backend truth.",
+      "Do not produce another label-heavy artifact that users would not export or share."
+    ],
+    "handoff_notes": "The next Codex work should be documentation reset plus backend contract design. The next Gemini work should wait for a stable DecisionDashboardState and DecisionMap contract. The Gemini prompt should be concise and focused on rendering a direct, dashboard-like Decision Intelligence experience with controls, visible update state, and no unsupported claims."
+  },
+  "metadata": {
+    "created_by": "Codex application-structure Agent Council simulation",
+    "schema_path": "project_docs/active/agent_council/council_output_schema.json",
+    "validator_path": "project_docs/active/agent_council/validate_council_json.py"
+  }
+}

--- a/project_docs/active/agent_council/outputs/application-structure-decision-dashboard/2026-05-23-application-structure-decision-dashboard-summary.md
+++ b/project_docs/active/agent_council/outputs/application-structure-decision-dashboard/2026-05-23-application-structure-decision-dashboard-summary.md
@@ -1,0 +1,101 @@
+# Application Structure Decision Dashboard Council Summary
+
+Date: 2026-05-23
+
+## Core Conclusion
+
+The council recommended changing AI_Tool from a broad AI toolbox with Decision Intelligence pieces into a practical Decision Intelligence builder dashboard.
+
+The main experience should help users build and update decision assets, not inspect internal contracts. The application should still use strong semantic concepts such as goals, drivers, outcomes, limits, breakdowns, evidence, scenarios, assumptions, and readiness, but those concepts should become practical controls and visible outputs.
+
+The council agreed that the product should be direct, useful, and down to earth. Technical terms should be available when they clarify the result, but they should not dominate the first screen.
+
+## Proposed Main Structure
+
+The council's strongest recommendation is a primary Decision Dashboard powered by a backend-owned `DecisionDashboardState`.
+
+The dashboard should bring together:
+
+Brief: a concise executive decision summary.
+
+Controls: editable goals, drivers, limits, breakdowns, assumptions, filters, and scenario inputs.
+
+Dataset Trust: compact dataset name, source, row count, column count, transform state, and stale-result status.
+
+Evidence Board: ranked observational evidence with quantified signals and limitations.
+
+Decision Map: a visual model of declared relationships and evidence coverage.
+
+Scenario Compare: bounded sensitivity comparisons, not causal forecasts.
+
+Advanced Gates: locked or gated areas for CDD, Monte Carlo, prediction, optimization, and final recommendations.
+
+Export: a share-ready decision asset, not a raw internal report.
+
+## Decision Map And CDD
+
+The council agreed not to lead with causal CDD yet.
+
+The near-term visual model should be called a Decision Map. It can show declared relationships and observational evidence coverage using nodes such as Goal, Driver, Limit, Breakdown, Evidence, Assumption, Unknown, Dataset, and Scenario.
+
+Edges should be labeled honestly as declared relationship, observed association, constraint, breakdown, assumption, or missing evidence. They should not imply causal proof.
+
+CDD should become a later gated advanced mode only when the app can explicitly capture causal direction, assumptions, confidence, validation notes, and unsupported simulation boundaries.
+
+## Product Language
+
+The council recommended translating internal terminology into practical business language:
+
+Objective becomes Goal.
+
+Lever becomes Driver or What You Can Change.
+
+Guardrail becomes Limit.
+
+Segment becomes Breakdown.
+
+Recommendation becomes Next Check or Suggested Investigation.
+
+Readiness becomes Can Run or Needs Fix.
+
+Technical terms should remain available in details, tooltips, contracts, and exports where useful, but the main dashboard should not read like an internal schema.
+
+## Surfaces To Demote Or Rewrite
+
+The council warned that old product surfaces could undermine the new direction.
+
+Legacy Strategic Recommendations should be renamed, demoted, or rewritten into Next Checks or Suggested Investigations.
+
+Autopilot should not stay prominent unless it produces a concrete decision asset. Otherwise, it should be hidden, renamed, or gated.
+
+AutoML and prediction-heavy surfaces should move behind Advanced Gates unless the app can clearly communicate validation, leakage, target suitability, and prediction boundaries.
+
+Generic workflow nodes should not compete with the Decision Dashboard as the main product experience.
+
+## Recommended Implementation Order
+
+First, reset active docs so the old Phase 4 Canonical Active Dataset path is no longer the default next work.
+
+Second, have Codex define the `DecisionDashboardState` backend contract. This should include frame summary, dataset trust, brief, controls, evidence summary, map, scenario preview, advanced gates, stale state, and export sections.
+
+Third, have Codex define the Decision Map contract with typed nodes and non-causal edge labels.
+
+Fourth, create a focused Gemini handoff for the Decision Dashboard frontend shell after the backend contract is stable.
+
+Fifth, prune or rewrite old overpromising surfaces and make export a first-class decision asset.
+
+## Acceptance Standard
+
+No unit of work should be considered complete just because fields exist, tests pass, docs are updated, or a renderer shows raw data.
+
+Completion requires a visible result that is obvious, useful, direct, truthful, and exportable where appropriate.
+
+The first meaningful acceptance flow should let a user change a driver, limit, assumption, breakdown, or scenario input and see the dashboard mark stale state or rerun the engine so the brief, evidence, map, and scenario comparison update.
+
+## Main Risk
+
+The biggest risk is building another visually dense surface that still behaves like a contract viewer. The dashboard must not become a wall of labels.
+
+The second biggest risk is overclaiming with CDD, predictions, optimization, or recommendations before the backend can truthfully support those capabilities.
+
+The council's answer is to make the dashboard practical now, keep causal and predictive work gated, and turn old overpromising surfaces into supporting tools only if they serve the new Decision Intelligence flow.

--- a/project_docs/active/agent_council/outputs/application-structure-decision-dashboard/README.md
+++ b/project_docs/active/agent_council/outputs/application-structure-decision-dashboard/README.md
@@ -1,0 +1,91 @@
+# Application Structure Decision Dashboard Council
+
+## Purpose
+
+This council topic asks the AI council to redesign the application structure around a clearer, more valuable Decision Intelligence product.
+
+The prior emergency compounding-results council concluded that the current phase roadmap is too focused on hidden technical fields, readiness labels, repeated prompt text, and internal guardrails. The new direction should produce visible, exportable, user-valued results: Executive Decision Brief, Dataset Trust, Visual Evidence Board, bounded Scenario Compare, and Advanced Analysis Readiness Gates.
+
+This follow-up council should turn that direction into a more concrete application structure.
+
+## User Direction
+
+The user is changing the landscape of the project.
+
+Semantic phrases, relationships, objectives, outcomes, levers, guardrails, segments, evidence, and readiness concepts are valid, but the product cannot feel like an internal contract viewer. AI_Tool is an application that helps users build things. It now needs to become a Decision Intelligence application that also helps users build practical decision assets.
+
+The results should feel one of a kind, direct, and to the point. Sometimes more is less. The app should use a down-to-earth business voice, with technical terms only where they clarify the result. The product should tell users what they should actually inspect, change, compare, or export without pretending to make final decisions for them.
+
+The app should move toward a dashboard-like approach where users can easily adjust levers, outcomes, scenarios, assumptions, filters, and decision-map relationships, then rerun or refresh the engine and see the brief, evidence, scenario comparison, and visual model update.
+
+## Decision Map And CDD Context
+
+The app does not currently have a first-class CDD or Decision Intelligence visual model builder.
+
+The near-term safe framing should be Decision Map, not causal model. A Decision Map can show declared relationships and observational evidence coverage without claiming causality. Nodes may include Objective, Lever, Guardrail, Segment, Evidence, Assumption, Unknown, Dataset, and Scenario.
+
+CDD-style modeling can become a later gated mode only if the app explicitly captures assumptions, causal direction, confidence, validation notes, and unsupported simulation boundaries. Until then, CDD should not imply causal proof, optimization, or Monte Carlo simulation.
+
+The strongest near-term option is a backend-generated Decision Map from the current decision workspace, followed by user-editable controls later. The user should be able to change a lever, adjust an assumption, switch a segment, compare a scenario, and rerun the engine to update the visible result.
+
+## What The New Council Should Answer
+
+The council should propose a clearer application structure, not another microscopic phase plan.
+
+It should answer what the first screen of the Decision Intelligence experience should be, what persistent dashboard controls users need, what visual models should exist, what results should be exportable, which low-value surfaces should be removed or demoted, and how Codex and Gemini should split the work.
+
+It should challenge whether old surfaces such as legacy recommendations, Autopilot, AutoML, and generic workflow nodes should remain prominent, be rewritten, be gated, or be removed from the main Decision Intelligence path.
+
+It should preserve truthful capability boundaries while making the product feel useful, practical, and exciting.
+
+## Required Sources
+
+`project_docs/INDEX.md`
+
+`project_docs/active/README.md`
+
+`project_docs/active/status/decision_intelligence_execution_status.md`
+
+`project_docs/active/rules/CODEX_FRONTEND_GUARDRAIL_READ_FIRST.md`
+
+`project_docs/active/agent_council/outputs/compounding-phase-results/2026-05-23-emergency-compounding-council.json`
+
+`project_docs/active/reviews/project_pruning_recommendations.md`
+
+`project_docs/active/contracts/decision_objects.md`
+
+## Output Handling
+
+Do not print the council JSON in chat.
+
+The council output must be saved as a JSON file in this folder:
+
+`project_docs/active/agent_council/outputs/application-structure-decision-dashboard/`
+
+Use a date-based filename such as:
+
+`2026-05-23-application-structure-decision-dashboard-council.json`
+
+After saving, validate it with:
+
+`python project_docs/active/agent_council/validate_council_json.py project_docs/active/agent_council/outputs/application-structure-decision-dashboard/2026-05-23-application-structure-decision-dashboard-council.json`
+
+## Paste-Ready Council Prompt
+
+Run a new Agent Council for AI_Tool focused on creating a clearer application structure for a practical Decision Intelligence product. Read `project_docs/INDEX.md`, `project_docs/active/README.md`, `project_docs/active/status/decision_intelligence_execution_status.md`, `project_docs/active/rules/CODEX_FRONTEND_GUARDRAIL_READ_FIRST.md`, `project_docs/active/agent_council/outputs/compounding-phase-results/2026-05-23-emergency-compounding-council.json`, `project_docs/active/reviews/project_pruning_recommendations.md`, and `project_docs/active/contracts/decision_objects.md`.
+
+Use the prior council result as the starting point. It said the current roadmap is too microscopic and too focused on hidden contract fields, readiness labels, repeated prompt text, capability boundaries, and internal structures. It recommended replacing the phase roadmap with visible outcomes: Executive Decision Brief with Dataset Trust, Visual Evidence Board and Decision Map, bounded Scenario Compare, executive-ready exports, and Advanced Analysis Readiness Gates.
+
+Now make that concrete. The user is changing the landscape of the project. Semantic phrases, relationships, objectives, outcomes, levers, guardrails, segments, evidence, and readiness concepts are valid, but this cannot feel like an internal contract viewer. AI_Tool is an application that helps users build things. It needs to become a Decision Intelligence application that also helps users build practical decision assets.
+
+The results we provide people need to be one of a kind, direct, and to the point. Sometimes more is less. Use a more down-to-earth business approach, with technical terms only when they clarify the result. The product should tell users what they should actually inspect, change, compare, or export without pretending to make final decisions for them.
+
+Consider a dashboard-like Decision Intelligence structure where users can easily change levers, outcomes, guardrails, assumptions, filters, segments, scenarios, and decision-map relationships, then rerun or refresh the engine and see the brief, evidence, scenario comparison, and visual model update.
+
+Include Decision Map and CDD options. Near term, prefer "Decision Map" over causal CDD unless the council defines explicit assumptions, causal direction, confidence, validation notes, and unsupported simulation boundaries. The Decision Map can show declared relationships and observational evidence coverage using nodes such as Objective, Lever, Guardrail, Segment, Evidence, Assumption, Unknown, Dataset, and Scenario. CDD should be a later gated mode unless the app can truthfully support causal modeling.
+
+Challenge the current app structure. Identify which surfaces should become the main Decision Intelligence experience, which should move behind gates, which should be rewritten, and which should be removed or demoted. Pay special attention to legacy recommendations, Autopilot, AutoML, generic workflow nodes, old Decision Panel surfaces, and any UI that produces many labels without a clear result.
+
+Preserve the Codex/Gemini ownership split. Codex owns backend truth, contracts, tests, architecture, review, and documentation. Gemini owns frontend implementation unless explicitly authorized otherwise.
+
+Do not print the JSON in chat. Save the final council JSON in `project_docs/active/agent_council/outputs/application-structure-decision-dashboard/` using a date-based filename, then validate it with `project_docs/active/agent_council/validate_council_json.py`. The JSON must match `project_docs/active/agent_council/council_output_schema.json`. The final recommendations must include a proposed application structure, primary user workflows, dashboard/control model, Decision Map/CDD approach, export model, low-value surface pruning plan, Codex backend tasks, Gemini frontend tasks, and acceptance criteria where no work is complete unless the visible result is obvious, useful, direct, truthful, and exportable where appropriate.

--- a/project_docs/active/agent_council/outputs/compounding-phase-results/2026-05-23-emergency-compounding-council.json
+++ b/project_docs/active/agent_council/outputs/compounding-phase-results/2026-05-23-emergency-compounding-council.json
@@ -1,0 +1,1489 @@
+{
+  "schema_version": "agent-council-output/v1",
+  "council_id": "emergency-compounding-phase-results-2026-05-23",
+  "generated_at": "2026-05-23T03:40:00Z",
+  "project_context": {
+    "project_name": "AI_Tool",
+    "current_workstream": "Decision Intelligence V3",
+    "planning_topic": "Replace the microscopic phase roadmap with a compounding-results roadmap where every unit creates obvious user-visible value.",
+    "context_summary": "Decision Intelligence V3 has completed reliability fields, semantic metadata, semantic frame completion, correction actions, ranked observational evidence, chat continuity, truthfulness hardening, and frontend rendering for recent backend slices. The active docs currently point to Phase 4 Canonical Active Dataset Contract as the next item. The exported workspace result supplied by the user is critical contrary evidence: it produced pages of readiness labels, repeated prompt text, capability boundaries, guardrails, and internal structure, but no obvious business value, quantified insight, scenario comparison, visual decision outcome, or share-worthy export. The council therefore rejects a hidden-contract-first roadmap as the organizing model and recommends outcome units centered on decision briefs, quantified evidence, scenario comparison, visual decision outcomes, and executive-ready exports while preserving truthful capability boundaries.",
+    "active_constraints": [
+      "Codex owns backend logic, contracts, tests, architecture, review, and active markdown coordination.",
+      "Gemini owns frontend implementation unless the user explicitly authorizes Codex frontend edits in the current session.",
+      "Current runtime must not imply fake simulation, optimization, causal inference, autonomous decisioning, or final recommendations.",
+      "Observational analysis remains the truth boundary until backend contracts, data prerequisites, and validation support stronger capability.",
+      "Every future implementation unit must have an obvious visible result in the app or an exportable artifact before it is considered complete.",
+      "Phase 4 dataset work is demoted from standalone hidden-contract priority unless it directly enables visible dataset trust inside a user-valued decision workflow."
+    ]
+  },
+  "sources_reviewed": [
+    {
+      "path": "project_docs/INDEX.md",
+      "source_type": "markdown",
+      "relevance": "Routes agents to active truth, current roadmap, council workflow, and compounding-results council topic.",
+      "reviewed_by": [
+        "architecture-guardian",
+        "implementation-planner"
+      ]
+    },
+    {
+      "path": "project_docs/active/README.md",
+      "source_type": "markdown",
+      "relevance": "Defines current status, scan rules, Phase 4 active-next framing, and emergency compounding-results council location.",
+      "reviewed_by": [
+        "architecture-guardian",
+        "product-ux-strategist",
+        "implementation-planner"
+      ]
+    },
+    {
+      "path": "project_docs/active/status/decision_intelligence_execution_status.md",
+      "source_type": "status",
+      "relevance": "Establishes completed Phase 1 through Phase 3 work, current Phase 4 dataset-contract priority, frontend build status, and verified capability boundaries.",
+      "reviewed_by": [
+        "architecture-guardian",
+        "decision-intelligence-specialist",
+        "data-ml-readiness-specialist",
+        "skeptic-qa-reviewer"
+      ]
+    },
+    {
+      "path": "project_docs/active/rules/CODEX_FRONTEND_GUARDRAIL_READ_FIRST.md",
+      "source_type": "markdown",
+      "relevance": "Preserves Codex/Gemini ownership split and review behavior for frontend handoffs.",
+      "reviewed_by": [
+        "architecture-guardian",
+        "implementation-planner"
+      ]
+    },
+    {
+      "path": "project_docs/active/decision_intelligence/current/next_focus_execution_plan.md",
+      "source_type": "markdown",
+      "relevance": "Contains the current microscopic phase roadmap and Phase 4 canonical active dataset sequencing challenged by this council.",
+      "reviewed_by": [
+        "product-ux-strategist",
+        "decision-intelligence-specialist",
+        "data-ml-readiness-specialist",
+        "implementation-planner"
+      ]
+    },
+    {
+      "path": "project_docs/active/ai_hand_off/README.md",
+      "source_type": "handoff",
+      "relevance": "Defines active Codex/Gemini handoff structure and ownership rules that the new roadmap must preserve.",
+      "reviewed_by": [
+        "architecture-guardian",
+        "implementation-planner"
+      ]
+    },
+    {
+      "path": "project_docs/active/ai_hand_off/phase_4_gemini_frontend_canonical_active_dataset.md",
+      "source_type": "handoff",
+      "relevance": "Shows Phase 4 is currently framed as frontend state and dataset visibility alignment, useful but insufficient as a standalone high-value outcome.",
+      "reviewed_by": [
+        "product-ux-strategist",
+        "data-ml-readiness-specialist",
+        "skeptic-qa-reviewer"
+      ]
+    },
+    {
+      "path": "project_docs/active/contracts/decision_objects.md",
+      "source_type": "contract",
+      "relevance": "Documents existing DecisionBrief, DecisionSignal, Scenario, DecisionScenarioPreview, ranked diagnostics, readiness, and dataset summary contracts that can be reorganized into visible product workflows.",
+      "reviewed_by": [
+        "architecture-guardian",
+        "decision-intelligence-specialist",
+        "data-ml-readiness-specialist"
+      ]
+    },
+    {
+      "path": "project_docs/active/agent_council/outputs/compounding-phase-results/README.md",
+      "source_type": "markdown",
+      "relevance": "Defines the emergency council topic and the requirement to restructure work around compounding visible product results.",
+      "reviewed_by": [
+        "product-ux-strategist",
+        "implementation-planner",
+        "skeptic-qa-reviewer"
+      ]
+    },
+    {
+      "path": "user-provided exported workspace result evidence from 2026-05-22 request",
+      "source_type": "other",
+      "relevance": "Critical user evidence that current output is technically dense but low-value: readiness labels, repeated prompt text, capability boundaries, guardrails, and internal structure without quantified insight, scenario comparison, visual decision outcome, or share-worthy export.",
+      "reviewed_by": [
+        "product-ux-strategist",
+        "decision-intelligence-specialist",
+        "skeptic-qa-reviewer"
+      ]
+    }
+  ],
+  "participating_agents": [
+    {
+      "agent_id": "architecture-guardian",
+      "role_name": "Architecture Guardian",
+      "perspective": "Protect explicit backend-owned truth, stable contracts, and honest capability boundaries while allowing the roadmap to stop over-optimizing hidden fields.",
+      "decision_rights": "Can block proposals that require fake capabilities, frontend-only inference, hidden coupling, or contract claims not supported by backend behavior."
+    },
+    {
+      "agent_id": "product-ux-strategist",
+      "role_name": "Product/UX Strategist",
+      "perspective": "Prioritize workflows users can see, understand, export, and value without reading docs or inspecting raw contracts.",
+      "decision_rights": "Can veto work units whose completion evidence is only tests, docs, hidden fields, or debug-like UI."
+    },
+    {
+      "agent_id": "decision-intelligence-specialist",
+      "role_name": "Decision Intelligence Specialist",
+      "perspective": "Keep the product centered on decision framing, quantified evidence, trade-off thinking, guardrails, assumptions, and structured insight loops.",
+      "decision_rights": "Can require every visible outcome to improve the decision workflow rather than generic chat or dataset polish."
+    },
+    {
+      "agent_id": "data-ml-readiness-specialist",
+      "role_name": "Data/ML Readiness Specialist",
+      "perspective": "Protect dataset truth, statistical validity, scenario assumptions, readiness gates, leakage awareness, and the line between observational evidence and unsupported prediction.",
+      "decision_rights": "Can defer Monte Carlo, causal claims, forecasting, or optimization until prerequisites and validation are explicit."
+    },
+    {
+      "agent_id": "skeptic-qa-reviewer",
+      "role_name": "Skeptic/QA Reviewer",
+      "perspective": "Attack vague acceptance criteria, happy-path demos, stale state, low-value outputs, and unverified user-visible behavior.",
+      "decision_rights": "Can reject a work unit as incomplete when the visible result is not obvious or export quality is not proven."
+    },
+    {
+      "agent_id": "implementation-planner",
+      "role_name": "Implementation Planner",
+      "perspective": "Convert the debate into a practical Codex/Gemini sequence with entry criteria, exit criteria, validation paths, and doc updates.",
+      "decision_rights": "Can sequence recommendations and assign Codex versus Gemini ownership."
+    }
+  ],
+  "conversation_rounds": {
+    "round_1_independent_proposals": [
+      {
+        "agent_id": "architecture-guardian",
+        "stance": "Keep truthful contracts, but stop treating hidden additive fields as product outcomes.",
+        "claims": [
+          "The existing backend contract work is useful infrastructure, but Phase 4 as a hidden canonical dataset contract will repeat the same value failure unless it is attached to a visible decision outcome.",
+          "Dataset truth should become a visible prerequisite inside a decision brief and scenario comparison workflow, not an isolated phase that users experience as another label surface."
+        ],
+        "challenged_assumptions": [
+          "A canonical active dataset contract is not automatically high-value just because many surfaces consume data.",
+          "A backend field is not complete product work unless a user can see why it matters."
+        ],
+        "evidence": [
+          "The active status says Phase 4 Canonical Active Dataset Contract is next.",
+          "The user evidence says the current exported workspace result showed internal labels and guardrails but no obvious business value.",
+          "The contract doc already contains DecisionBrief, DecisionSignal, Scenario, and DecisionScenarioPreview shapes that can be organized into visible outcomes."
+        ],
+        "proposed_changes": [
+          "Replace phase labels with outcome units: Decision Brief, Evidence Explorer, Scenario Compare, Export Pack, and Readiness Gate.",
+          "Make dataset contract work a thin enabling slice inside the first outcome unit, visible as dataset identity, freshness, row count, transform state, and stale-data warnings."
+        ],
+        "risks_flagged": [
+          "If Phase 4 proceeds unchanged, the project will likely ship another technically correct but user-invisible surface.",
+          "If scenario work moves up without boundaries, the app may imply unsupported causal or predictive capability."
+        ]
+      },
+      {
+        "agent_id": "product-ux-strategist",
+        "stance": "The next unit must create an executive-ready result a user would want to share.",
+        "claims": [
+          "The product should lead with a one-page decision outcome, not readiness diagnostics.",
+          "A user should see the business question, objective, levers, guardrails, top quantified evidence, limitations, and next analysis choices in one coherent view."
+        ],
+        "challenged_assumptions": [
+          "More inspectability is not the same as clarity.",
+          "Repeated prompt text and guardrail labels are not a product result."
+        ],
+        "evidence": [
+          "The user explicitly reported no quantified insight, scenario comparison, visual decision outcome, or export-worthy result.",
+          "The status doc confirms PDF export refactoring has already made high-fidelity procedural export a usable asset."
+        ],
+        "proposed_changes": [
+          "Move Decision Brief generation and export ahead of broad canonical dataset alignment.",
+          "Require every future handoff to include the exact visible screen, the export artifact, and the user-facing acceptance prompt."
+        ],
+        "risks_flagged": [
+          "A dense brief could become another debug report if it repeats readiness labels instead of synthesizing evidence.",
+          "Over-polished export could hide capability boundaries if the copy is not disciplined."
+        ]
+      },
+      {
+        "agent_id": "decision-intelligence-specialist",
+        "stance": "Center the roadmap on decision loops: frame, evidence, compare, decide what to inspect next.",
+        "claims": [
+          "The current work has strong pieces, but they are not composed into a decision workflow that creates compounding insight.",
+          "Scenario comparison should move up, but it must begin as bounded sensitivity comparison or direct-adjustment scenarios, not causal Monte Carlo simulation."
+        ],
+        "challenged_assumptions": [
+          "Ranked observational evidence is not enough unless it is tied to the user's objective and surfaced as quantified trade-off context.",
+          "Scenario comparison does not have to wait for full ML readiness if the app is explicit that early scenarios are assumption-based sensitivity views."
+        ],
+        "evidence": [
+          "Phase 3 ranked diagnostics exist and are rendered.",
+          "The contract doc already defines Scenario and DecisionScenarioPreview objects with direct adjustment assumptions.",
+          "The current plan defers simulation and trade-off contract design to Phase 6."
+        ],
+        "proposed_changes": [
+          "Create a visible Decision Outcome workspace that combines corrected frame, ranked evidence, guardrail status, and quantified deltas.",
+          "Add bounded Scenario Compare as the second outcome unit, using explicit assumptions and direct adjustments before Monte Carlo."
+        ],
+        "risks_flagged": [
+          "Scenario comparison may be mistaken for prediction if labels are not strict.",
+          "A decision brief without quantified values will fail the same way the exported workspace result failed."
+        ]
+      },
+      {
+        "agent_id": "data-ml-readiness-specialist",
+        "stance": "Dataset truth still matters, but it must be visibly tied to trust and value.",
+        "claims": [
+          "Canonical active dataset work should not be removed, but it should be scoped to support visible trust: which dataset, what rows and columns, what transform state, and whether the decision result is stale.",
+          "Monte Carlo can be planned as a readiness-gated future workflow, but not implemented as real simulation until assumptions, distributions, validation, and leakage checks exist."
+        ],
+        "challenged_assumptions": [
+          "Dataset alignment alone will not satisfy the user's need for business value.",
+          "Monte Carlo is not automatically more valuable if the input assumptions are invisible or fake."
+        ],
+        "evidence": [
+          "Phase 4 handoff asks for dataset source, ID, row count, column count, and transform state across surfaces.",
+          "The next-focus plan defers ML readiness diagnostics and simulation design.",
+          "The contract doc has dataset summaries and scenario scaffolds, but current acceptance is not tied to export-worthy outcomes."
+        ],
+        "proposed_changes": [
+          "Fold Phase 4 into a visible Dataset Trust Strip and stale-result gate inside Decision Brief and Scenario Compare.",
+          "Move ML readiness diagnostics earlier only when expressed as a visible gate explaining why prediction or Monte Carlo is not available yet."
+        ],
+        "risks_flagged": [
+          "Skipping dataset truth would make future briefs and scenario comparisons unreliable.",
+          "Moving Monte Carlo too early would create false precision."
+        ]
+      },
+      {
+        "agent_id": "skeptic-qa-reviewer",
+        "stance": "No work should pass unless the user can verify the visible payoff without reading docs.",
+        "claims": [
+          "The current acceptance criteria overvalue build success, field presence, and documentation truth.",
+          "Every outcome unit needs a demo prompt, a visible acceptance path, an export check, and a negative case that proves unsupported capabilities remain truthful."
+        ],
+        "challenged_assumptions": [
+          "A browser flow is not enough if it only confirms labels render.",
+          "A PDF export is not valuable if it contains generic readiness text instead of quantified evidence and a clear decision artifact."
+        ],
+        "evidence": [
+          "The user evidence says the exported workspace result was not exciting or shareable.",
+          "The active docs list many completed slices, yet the current user still perceives low visible payoff."
+        ],
+        "proposed_changes": [
+          "Create a hard Definition of Done: visible result, quantified evidence, scenario or comparison where applicable, exportable artifact, truthful boundary, and status-doc update.",
+          "Add regression fixtures for the same prompt before and after each outcome unit to ensure the visible result compounds instead of resetting."
+        ],
+        "risks_flagged": [
+          "Agents may mark work complete after adding another renderer.",
+          "Outcome demos may become hand-picked if not tied to realistic acceptance prompts and stale-state checks."
+        ]
+      },
+      {
+        "agent_id": "implementation-planner",
+        "stance": "Replace the phase roadmap with a compounding outcome ladder and keep ownership intact.",
+        "claims": [
+          "The next roadmap should be organized by user-visible deliverables rather than Phase 4, Phase 5, and Phase 6 labels.",
+          "Codex should define backend outcome contracts and acceptance gates; Gemini should implement visible UI and export surfaces from those contracts."
+        ],
+        "challenged_assumptions": [
+          "The current active handoff should not remain active unchanged after this council because it is framed around dataset state rather than a visible decision result.",
+          "Documentation should not keep pointing agents to Phase 4 as the next work after the user has rejected the value model."
+        ],
+        "evidence": [
+          "The active handoff folder lists Phase 4 canonical active dataset as active next.",
+          "The compounding-results README explicitly asks for a replacement roadmap and doc changes after acceptance."
+        ],
+        "proposed_changes": [
+          "Create outcome unit 1: Executive Decision Brief with Dataset Trust Strip.",
+          "Create outcome unit 2: Visual Evidence Board with quantified ranked diagnostics.",
+          "Create outcome unit 3: Bounded Scenario Compare with direct adjustments and guardrail impact.",
+          "Create outcome unit 4: Export Pack for PDF/share-ready decision brief.",
+          "Defer full Monte Carlo to readiness-gated design unless explicit assumptions and validations are implemented."
+        ],
+        "risks_flagged": [
+          "The roadmap could become too broad unless each outcome unit is thin, demoable, and acceptance-gated.",
+          "Docs must be updated immediately after acceptance to prevent agents from resuming the old Phase 4 path."
+        ]
+      }
+    ],
+    "round_2_critiques": [
+      {
+        "agent_id": "architecture-guardian",
+        "stance": "Approve outcome orientation but constrain scenarios and exports to backend-owned truth.",
+        "claims": [
+          "Scenario Compare can move up only if the backend contract states direct adjustment assumptions and refuses unsupported causal claims.",
+          "Executive exports must preserve limitations and truth boundaries without making the UI feel like a wall of guardrails."
+        ],
+        "challenged_assumptions": [
+          "A Gemini-only visual solution cannot infer quantified insight that the backend did not provide.",
+          "CDD or Monte Carlo terminology should not appear as a product promise before the backend can support it."
+        ],
+        "evidence": [
+          "The frontend guardrail assigns frontend implementation to Gemini and backend contracts to Codex.",
+          "The decision objects contract already distinguishes scenarios and observational boundary fields."
+        ],
+        "proposed_changes": [
+          "Codex must produce a brief-focused contract before Gemini builds the primary result view.",
+          "Any scenario comparison UI must render assumption labels and unsupported capability boundaries from backend fields."
+        ],
+        "risks_flagged": [
+          "Frontend-only synthesis would create drift from backend truth.",
+          "Monte Carlo labels would overclaim if implemented before readiness gates."
+        ]
+      },
+      {
+        "agent_id": "product-ux-strategist",
+        "stance": "Reject another diagnostics surface; the result must look like a decision product.",
+        "claims": [
+          "A Dataset Trust Strip is only valuable if it is visually subordinate to the business result.",
+          "The first screen after a decision prompt should show a synthesized brief and visual evidence, not a raw contract explorer."
+        ],
+        "challenged_assumptions": [
+          "Users do not care about dataset precedence rules until stale or conflicting data affects their decision result.",
+          "Completeness should be judged by whether the user can explain the finding to someone else."
+        ],
+        "evidence": [
+          "The user called out no obvious business value and no shareable result.",
+          "The Phase 4 handoff acceptance is mainly dataset identity and state propagation."
+        ],
+        "proposed_changes": [
+          "Make visible business value the primary acceptance check and dataset truth the trust layer.",
+          "Use export quality as a forcing function for concise synthesis."
+        ],
+        "risks_flagged": [
+          "A trust strip could become another label-heavy band.",
+          "A brief could become generic if not anchored to quantified evidence."
+        ]
+      },
+      {
+        "agent_id": "decision-intelligence-specialist",
+        "stance": "The roadmap should compound from existing Phase 3 work rather than discard it.",
+        "claims": [
+          "Ranked observational diagnostics are valuable if transformed into an Evidence Board with numbers, relevance, limitations, and next investigation options.",
+          "CDD can be useful as a visible decision dependency map, but it should represent declared objective, levers, guardrails, segments, and assumptions rather than causal certainty."
+        ],
+        "challenged_assumptions": [
+          "Removing recently built work is unnecessary if it can be composed into a better product result.",
+          "A decision brief alone may be too static without a comparison or next-step workflow."
+        ],
+        "evidence": [
+          "Phase 3 correction and ranked observational evidence are complete.",
+          "The contract has semantic coverage and data sufficiency fields that can support an evidence board."
+        ],
+        "proposed_changes": [
+          "Use Phase 3 diagnostics as the evidence engine for the brief and visual board.",
+          "Introduce a CDD-style decision map as a bounded frame visualization, not a causal graph."
+        ],
+        "risks_flagged": [
+          "CDD language could imply causality if not renamed or bounded.",
+          "Evidence ranking could be mistaken for recommendation priority."
+        ]
+      },
+      {
+        "agent_id": "data-ml-readiness-specialist",
+        "stance": "Move scenario comparison up, but keep Monte Carlo behind a visible readiness gate.",
+        "claims": [
+          "Direct-adjustment scenario comparison is feasible earlier because it can be transparent and assumption-labeled.",
+          "Monte Carlo requires explicit uncertainty inputs, distributions, correlations, validation, and communication of non-causal assumptions."
+        ],
+        "challenged_assumptions": [
+          "Monte Carlo should not be added just because it looks advanced.",
+          "ML readiness diagnostics should be tied to visible user decisions, not another hidden capability table."
+        ],
+        "evidence": [
+          "The current plan defers ML readiness diagnostics and simulation design.",
+          "The contract's scenario scaffold already contains direct metric adjustments and assumptions."
+        ],
+        "proposed_changes": [
+          "Create Scenario Compare now as assumption-based sensitivity analysis.",
+          "Create Monte Carlo Readiness Card later that explains exactly what is missing before probabilistic simulation can run."
+        ],
+        "risks_flagged": [
+          "False precision is likely if probabilistic outputs appear without enough assumptions.",
+          "Users may treat direct adjustments as forecast if copy is weak."
+        ]
+      },
+      {
+        "agent_id": "skeptic-qa-reviewer",
+        "stance": "Every proposal needs a failure-mode acceptance check.",
+        "claims": [
+          "A good demo must prove the app avoids stale data, unsupported simulation claims, and generic exports.",
+          "Acceptance should fail if the result could be generated without the user's dataset and decision frame."
+        ],
+        "challenged_assumptions": [
+          "One happy-path prompt is not enough.",
+          "Status docs are insufficient evidence unless paired with a user-visible artifact."
+        ],
+        "evidence": [
+          "The exported workspace result apparently contained repeated prompt text, which suggests synthesis quality is not currently gated.",
+          "The active status emphasizes many technical completions that did not add perceived value."
+        ],
+        "proposed_changes": [
+          "Require three acceptance prompts per outcome unit: complete frame, incomplete frame, and unsupported advanced request.",
+          "Require export inspection for brief and scenario units."
+        ],
+        "risks_flagged": [
+          "Agents may pass visual work by rendering all fields instead of synthesizing them.",
+          "The user may still see low value if quantified insight is optional."
+        ]
+      },
+      {
+        "agent_id": "implementation-planner",
+        "stance": "The replacement roadmap must be narrow enough to execute without losing momentum.",
+        "claims": [
+          "The first outcome unit should be a thin vertical slice: one prompt creates a brief, evidence summary, dataset trust strip, and export artifact.",
+          "Phase 4 docs should be paused or rewritten after this council is accepted."
+        ],
+        "challenged_assumptions": [
+          "A complete redesign of all data surfaces is too broad for the next step.",
+          "A compounding roadmap should not mean every high-value idea moves into the first implementation unit."
+        ],
+        "evidence": [
+          "Codex harness rules require scoped plans and narrow verification.",
+          "The Phase 4 handoff names many frontend consumers, which is broad and likely to become another infrastructure-heavy slice."
+        ],
+        "proposed_changes": [
+          "Start with Decision Brief plus Dataset Trust Strip as the first vertical outcome.",
+          "Then layer Evidence Board, Scenario Compare, Export Pack, and Monte Carlo readiness in sequence."
+        ],
+        "risks_flagged": [
+          "If the first unit touches too many surfaces, it will recreate the microscopic phase problem under a bigger label.",
+          "If docs are not changed, another agent may continue Phase 4 unchanged."
+        ]
+      }
+    ],
+    "round_3_reconciliation": [
+      {
+        "agent_id": "architecture-guardian",
+        "stance": "Resolved: Phase 4 remains only as an enabling trust layer inside visible outcomes.",
+        "claims": [
+          "The council should not delete dataset truth work, but it should no longer be the primary roadmap item.",
+          "Backend contracts must provide synthesized brief data, dataset trust data, and scenario assumptions before Gemini renders them."
+        ],
+        "challenged_assumptions": [
+          "Dataset truth is not a product outcome by itself.",
+          "Frontend can improve presentation but cannot manufacture decision intelligence."
+        ],
+        "evidence": [
+          "Phase 4 handoff is active but insufficient against user evidence.",
+          "DecisionBrief and Scenario contracts already exist as stronger visible anchors."
+        ],
+        "proposed_changes": [
+          "Rename the next Codex work from Phase 4 Canonical Active Dataset Contract to Outcome 1: Executive Decision Brief with Dataset Trust.",
+          "Keep dataset precedence rules scoped to the result being briefed and exported."
+        ],
+        "risks_flagged": [
+          "Contract churn may increase if the brief contract is not additive.",
+          "Existing frontend handoff must be superseded cleanly."
+        ]
+      },
+      {
+        "agent_id": "product-ux-strategist",
+        "stance": "Resolved: The first visible artifact must be a decision brief, not a state alignment screen.",
+        "claims": [
+          "The user should immediately see quantified evidence and a shareable narrative.",
+          "The brief should have a clear visual hierarchy: business result first, trust and boundaries second."
+        ],
+        "challenged_assumptions": [
+          "Users should not have to inspect capability boundaries to discover value."
+        ],
+        "evidence": [
+          "User evidence rejected label-heavy output.",
+          "PDF export tooling has already been refactored for high-fidelity procedural generation."
+        ],
+        "proposed_changes": [
+          "Acceptance for Outcome 1 requires a visible brief and a procedural PDF export with quantified evidence.",
+          "Readiness and unsupported capability labels must be summarized, not dumped."
+        ],
+        "risks_flagged": [
+          "Brief copy could over-summarize and hide important limitations.",
+          "Export could lag behind UI if not part of the same acceptance gate."
+        ]
+      },
+      {
+        "agent_id": "decision-intelligence-specialist",
+        "stance": "Resolved: Scenario Compare moves up, Monte Carlo stays gated.",
+        "claims": [
+          "Users need comparison to feel decision value, but direct-adjustment sensitivity is the honest near-term form.",
+          "CDD should be framed as a Decision Map showing current frame and dependencies, not causal proof."
+        ],
+        "challenged_assumptions": [
+          "Scenario comparison must not be deferred until full simulation if a bounded version can add value now.",
+          "Monte Carlo should not be implemented before readiness gates."
+        ],
+        "evidence": [
+          "The user explicitly named scenario comparison, CDD, Monte Carlo, and executive-ready exports as high-value candidates.",
+          "The contract contains scenario scaffolds and direct adjustment assumptions."
+        ],
+        "proposed_changes": [
+          "Outcome 2 should turn ranked diagnostics into a visual evidence board and Decision Map.",
+          "Outcome 3 should add bounded Scenario Compare with guardrail impact and assumptions."
+        ],
+        "risks_flagged": [
+          "Decision Map may be misread as causal unless labels are precise.",
+          "Scenario Compare must distinguish sensitivity from forecast."
+        ]
+      },
+      {
+        "agent_id": "data-ml-readiness-specialist",
+        "stance": "Resolved: ML readiness becomes visible gating for advanced capabilities.",
+        "claims": [
+          "Readiness labels are low-value when dumped as content, but high-value when they explain why advanced analysis is unavailable and what data would unlock it.",
+          "Monte Carlo readiness should be a visible card after Scenario Compare, not a hidden contract field."
+        ],
+        "challenged_assumptions": [
+          "Users do not need more readiness fields; they need readiness consequences."
+        ],
+        "evidence": [
+          "The active plan currently places ML readiness after dataset alignment.",
+          "The user evidence says readiness labels without payoff are low-value."
+        ],
+        "proposed_changes": [
+          "Outcome 4 should add visible Advanced Analysis Readiness for Monte Carlo, prediction, and optimization, with exact missing prerequisites.",
+          "Do not implement probabilistic simulation until the readiness card can pass."
+        ],
+        "risks_flagged": [
+          "Readiness cards can become another wall of labels if not tied to unlockable workflows.",
+          "Monte Carlo requirements may require additional data contracts."
+        ]
+      },
+      {
+        "agent_id": "skeptic-qa-reviewer",
+        "stance": "Resolved: The new Definition of Done is user-visible and export-gated.",
+        "claims": [
+          "No future unit is complete unless the visible screen and export prove value.",
+          "Tests and docs remain necessary but are not sufficient."
+        ],
+        "challenged_assumptions": [
+          "A renderer that shows fields is not enough.",
+          "A build passing is not product acceptance."
+        ],
+        "evidence": [
+          "The user evidence is a direct failure of output acceptance quality.",
+          "The active docs currently emphasize technical completions."
+        ],
+        "proposed_changes": [
+          "Each outcome unit needs an acceptance prompt, visible result, export artifact when applicable, negative capability-boundary case, and status-doc update.",
+          "Add regression checks that fail on repeated prompt dumps and missing quantified evidence."
+        ],
+        "risks_flagged": [
+          "Acceptance could become subjective unless examples are concrete.",
+          "Export verification may add work but is required for the user's stated value bar."
+        ]
+      },
+      {
+        "agent_id": "implementation-planner",
+        "stance": "Resolved: The roadmap becomes an outcome ladder with Codex backend contracts before Gemini UI handoffs.",
+        "claims": [
+          "The council can preserve ownership split while changing acceptance: Codex produces value-focused backend contracts and Gemini renders obvious results.",
+          "The Phase 4 handoff should be superseded by a new Gemini handoff only after Codex defines Outcome 1 contract and acceptance."
+        ],
+        "challenged_assumptions": [
+          "The existing active next handoff should not remain the entry point after this council."
+        ],
+        "evidence": [
+          "AI handoff README assigns Codex coordination and Gemini frontend implementation.",
+          "Compounding-results README requires doc changes after acceptance."
+        ],
+        "proposed_changes": [
+          "Implement Outcome 1 first, then Evidence Board, Scenario Compare, Export Pack, and Advanced Readiness.",
+          "Update active docs to point to the new compounding roadmap and mark the old Phase 4 handoff as superseded or narrowed."
+        ],
+        "risks_flagged": [
+          "Docs can drift if not updated immediately.",
+          "Outcome 1 must not expand into a broad rewrite."
+        ]
+      }
+    ],
+    "round_4_synthesis": [
+      {
+        "agent_id": "implementation-planner",
+        "stance": "Final synthesis: replace the phase roadmap with compounding outcome units.",
+        "claims": [
+          "The old roadmap should be superseded as the organizing model.",
+          "The next work should be a thin vertical Decision Brief with Dataset Trust and export acceptance."
+        ],
+        "challenged_assumptions": [
+          "The current Phase 4 dataset-contract direction should not proceed unchanged."
+        ],
+        "evidence": [
+          "Reviewed active docs and user evidence support a pivot away from hidden contract fields.",
+          "Existing contracts contain enough decision objects to support a value-focused first outcome."
+        ],
+        "proposed_changes": [
+          "Adopt the resolved recommendations in this JSON as the new planning source.",
+          "Update active documentation after user acceptance."
+        ],
+        "risks_flagged": [
+          "The roadmap must stay honest about unsupported simulation and optimization.",
+          "The first unit must not expand into an all-surface rewrite."
+        ]
+      }
+    ]
+  },
+  "major_disagreements": [
+    {
+      "disagreement_id": "disagreement-phase-4-priority",
+      "topic": "Whether Phase 4 Canonical Active Dataset Contract should remain the next primary roadmap item",
+      "positions": [
+        {
+          "agent_id": "architecture-guardian",
+          "position": "Keep dataset truth, but demote it from standalone phase to visible trust layer.",
+          "rationale": "Dataset truth is architecturally necessary, but hidden precedence rules will not solve the user's value complaint."
+        },
+        {
+          "agent_id": "product-ux-strategist",
+          "position": "Do not proceed with Phase 4 unchanged.",
+          "rationale": "The current handoff centers state alignment rather than an exciting result users can export or share."
+        },
+        {
+          "agent_id": "data-ml-readiness-specialist",
+          "position": "Preserve a narrow dataset trust slice.",
+          "rationale": "Briefs and scenarios are unreliable without visible dataset identity, row counts, columns, and transform state."
+        }
+      ],
+      "status": "resolved",
+      "resolution": "Phase 4 is superseded as the primary roadmap item. Its useful parts become a Dataset Trust Strip and stale-result gate inside Outcome 1 and later scenario workflows."
+    },
+    {
+      "disagreement_id": "disagreement-scenario-timing",
+      "topic": "Whether scenario comparison should move up before ML readiness and simulation design",
+      "positions": [
+        {
+          "agent_id": "decision-intelligence-specialist",
+          "position": "Move bounded scenario comparison up.",
+          "rationale": "Scenario comparison is a visible high-value workflow and can begin as transparent sensitivity analysis."
+        },
+        {
+          "agent_id": "data-ml-readiness-specialist",
+          "position": "Do not implement Monte Carlo yet.",
+          "rationale": "Probabilistic simulation needs assumptions, distributions, validation, and leakage checks."
+        },
+        {
+          "agent_id": "architecture-guardian",
+          "position": "Allow direct-adjustment scenarios only with backend-owned assumptions and refusal boundaries.",
+          "rationale": "The app must not imply causal forecasting, optimization, or final recommendations."
+        }
+      ],
+      "status": "resolved",
+      "resolution": "Scenario Compare moves up as direct-adjustment sensitivity comparison with explicit assumptions, guardrail impact, and non-causal labeling. Monte Carlo remains readiness-gated and design-only until prerequisites are met."
+    },
+    {
+      "disagreement_id": "disagreement-cdd-language",
+      "topic": "Whether CDD-style decision mapping should be introduced",
+      "positions": [
+        {
+          "agent_id": "decision-intelligence-specialist",
+          "position": "Introduce a Decision Map.",
+          "rationale": "A visual map of objective, levers, guardrails, segments, assumptions, and evidence helps users understand the decision frame."
+        },
+        {
+          "agent_id": "data-ml-readiness-specialist",
+          "position": "Avoid causal language.",
+          "rationale": "CDD could be read as causal dependency if the app has not proven causal assumptions."
+        },
+        {
+          "agent_id": "product-ux-strategist",
+          "position": "Use visual mapping only if it clarifies the decision outcome.",
+          "rationale": "A diagram is valuable when it helps explain the result, not when it adds another internal structure view."
+        }
+      ],
+      "status": "resolved",
+      "resolution": "Use the label Decision Map, not causal diagram, for the near term. It may show declared relationships and evidence coverage, but not causal effects."
+    }
+  ],
+  "resolved_recommendations": [
+    {
+      "recommendation_id": "rec-replace-phases-with-outcome-ladder",
+      "title": "Replace microscopic phases with a compounding outcome ladder",
+      "summary": "Stop organizing the roadmap around Phase 4, Phase 5, and Phase 6 technical slices. Organize it around user-visible outcomes: Executive Decision Brief, Visual Evidence Board, Bounded Scenario Compare, Export Pack, and Advanced Analysis Readiness.",
+      "originating_agents": [
+        "product-ux-strategist",
+        "implementation-planner",
+        "skeptic-qa-reviewer"
+      ],
+      "source_paths": [
+        "project_docs/active/agent_council/outputs/compounding-phase-results/README.md",
+        "project_docs/active/decision_intelligence/current/next_focus_execution_plan.md",
+        "user-provided exported workspace result evidence from 2026-05-22 request"
+      ],
+      "priority": "critical",
+      "confidence": 0.95,
+      "implementation_timing": "now",
+      "rationale": "The user evidence proves the current phase model can complete technically valid work while failing product value. Outcome units force every slice to create something visible, understandable, exportable, and worth sharing.",
+      "impacted_areas": [
+        "project roadmap docs",
+        "AI handoff docs",
+        "Decision Intelligence backend contract planning",
+        "Gemini frontend acceptance criteria",
+        "export verification"
+      ],
+      "frontend_implications": [
+        "Gemini handoffs must describe the visible screen and export result, not only fields to render.",
+        "Frontend completion requires a browser-visible result whose business value is obvious."
+      ],
+      "backend_implications": [
+        "Codex must define synthesized outcome contracts, not just additive metadata fields.",
+        "Backend output should prefer brief-ready values, quantified evidence, assumptions, and limitations over raw diagnostic dumps."
+      ],
+      "contract_considerations": [
+        "Keep existing fields additive and backward-compatible.",
+        "Use existing DecisionBrief, DecisionSignal, Scenario, DecisionScenarioPreview, ranked diagnostics, and Dataset Summary contracts where possible.",
+        "Add only thin synthesized fields when necessary for a visible outcome."
+      ],
+      "testing_considerations": [
+        "Each outcome unit must include a complete-frame acceptance prompt, incomplete-frame blocked prompt, and unsupported-advanced-capability prompt.",
+        "Tests should fail when quantified evidence is absent from a supposedly complete brief.",
+        "Docs and tests are required but not sufficient without visible proof."
+      ],
+      "risks": [
+        "Outcome names could become phase labels in disguise if acceptance remains technical.",
+        "The first outcome could become too broad unless scoped to a vertical slice."
+      ],
+      "dependencies": [
+        "User acceptance of this council result",
+        "Docs update that supersedes the current Phase 4-first roadmap"
+      ],
+      "acceptance_signals": [
+        "Active docs no longer direct the next agent to start Phase 4 canonical dataset work unchanged.",
+        "The next implementation plan uses outcome units with visible and exportable acceptance criteria.",
+        "Each unit states what the user sees, what can be exported, what remains unsupported, and how stale or missing data is shown."
+      ]
+    },
+    {
+      "recommendation_id": "rec-outcome-1-executive-decision-brief",
+      "title": "Make the next implementation unit an Executive Decision Brief with Dataset Trust",
+      "summary": "The next build should produce a concise, quantified decision brief from a prompt-first decision workspace. It should show the business question, objective, levers, guardrails, dataset identity, top quantified evidence, limitations, and allowed next actions in one user-facing result.",
+      "originating_agents": [
+        "product-ux-strategist",
+        "decision-intelligence-specialist",
+        "data-ml-readiness-specialist",
+        "implementation-planner"
+      ],
+      "source_paths": [
+        "project_docs/active/contracts/decision_objects.md",
+        "project_docs/active/status/decision_intelligence_execution_status.md",
+        "project_docs/active/ai_hand_off/phase_4_gemini_frontend_canonical_active_dataset.md",
+        "user-provided exported workspace result evidence from 2026-05-22 request"
+      ],
+      "priority": "critical",
+      "confidence": 0.9,
+      "implementation_timing": "now",
+      "rationale": "The user explicitly needs obvious business value and export-worthy output. A brief composes existing readiness, semantics, corrections, ranked evidence, dataset summary, and export capabilities into a result users can understand.",
+      "impacted_areas": [
+        "backend decision workspace service",
+        "backend decision chat service",
+        "decision object contracts",
+        "AI Shell result rendering",
+        "Decision Workspace view",
+        "PDF export mapping",
+        "active status docs"
+      ],
+      "frontend_implications": [
+        "Gemini should render the brief as a primary result surface, not a diagnostics panel.",
+        "Readiness and unsupported capabilities should be summarized as caveats or locked advanced actions, not dumped as the main content.",
+        "Dataset trust should appear as a compact strip showing dataset name, source, row count, column count, transform state, and stale/override state."
+      ],
+      "backend_implications": [
+        "Codex should produce or normalize a brief-ready object from existing workspace analysis and ranked diagnostics.",
+        "The backend should include quantified evidence summaries and limitations derived from actual diagnostics.",
+        "The backend must preserve observational_analysis_only truth boundary."
+      ],
+      "contract_considerations": [
+        "Prefer extending DecisionBrief with brief sections that reference existing DecisionSignal and ranked diagnostic IDs.",
+        "Dataset Summary should include transform state or cleaning state where available.",
+        "No final recommendation field should be introduced."
+      ],
+      "testing_considerations": [
+        "Test that the May-style revenue prompt produces a brief with objective, levers, guardrails, segments, dataset summary, and at least one quantified evidence item when data supports it.",
+        "Test that missing or unparsed guardrails block analysis and produce a brief-ready blocker instead of fake insight.",
+        "Test that unsupported simulation requests remain bounded and are not converted into recommendations."
+      ],
+      "risks": [
+        "The brief could become generic if quantified evidence is optional.",
+        "Dataset trust could become another label wall if visually overemphasized."
+      ],
+      "dependencies": [
+        "Existing Phase 3 ranked diagnostics",
+        "Existing dataset summary fields",
+        "Existing procedural PDF export infrastructure"
+      ],
+      "acceptance_signals": [
+        "A user can run one decision prompt and see a concise decision brief with quantified evidence without opening raw JSON.",
+        "The brief identifies the active dataset and whether the result is stale or based on an override.",
+        "The brief can be exported to a PDF that contains the same business result, quantified evidence, caveats, and dataset trust context.",
+        "The output does not repeat the full prompt as filler and does not lead with readiness labels."
+      ]
+    },
+    {
+      "recommendation_id": "rec-narrow-phase-4-into-dataset-trust",
+      "title": "Narrow Phase 4 dataset work into a visible Dataset Trust Strip",
+      "summary": "Preserve the useful dataset-truth work but stop treating broad canonical active dataset alignment as the next standalone milestone. Implement the smallest dataset identity and stale-result behavior needed to make decision briefs and scenario comparisons trustworthy.",
+      "originating_agents": [
+        "architecture-guardian",
+        "data-ml-readiness-specialist",
+        "implementation-planner"
+      ],
+      "source_paths": [
+        "project_docs/active/ai_hand_off/phase_4_gemini_frontend_canonical_active_dataset.md",
+        "project_docs/active/decision_intelligence/current/next_focus_execution_plan.md",
+        "project_docs/active/contracts/decision_objects.md"
+      ],
+      "priority": "high",
+      "confidence": 0.88,
+      "implementation_timing": "now",
+      "rationale": "Dataset alignment matters, but a broad all-surface state project would not answer the user's complaint. A visible trust strip compounds into briefs, evidence boards, scenarios, and exports.",
+      "impacted_areas": [
+        "frontend active dataset state",
+        "dataset summary contract",
+        "AI Chat",
+        "Decisions workspace",
+        "export mapping",
+        "active handoff docs"
+      ],
+      "frontend_implications": [
+        "Gemini should show dataset identity only where it changes trust in the decision result.",
+        "Explicit overrides and stale state must be visible when present.",
+        "The old all-surfaces handoff should be replaced or narrowed."
+      ],
+      "backend_implications": [
+        "Codex should define what dataset summary fields are backend-owned versus frontend-derived.",
+        "Backend decision outputs should echo the dataset summary used for the brief or scenario."
+      ],
+      "contract_considerations": [
+        "Add transform_state or cleaning_state only if the current app can truthfully supply it.",
+        "Do not invent dataset IDs where none exist; mark unknowns honestly.",
+        "Maintain backward-compatible Dataset Summary fields."
+      ],
+      "testing_considerations": [
+        "Verify changing or selecting a dataset changes the dataset summary used by the decision brief.",
+        "Verify stale workspace results are marked or invalidated rather than silently reused.",
+        "Verify exports include the same dataset identity shown in the UI."
+      ],
+      "risks": [
+        "Too much surface alignment could bloat the first outcome unit.",
+        "Unknown dataset metadata could tempt frontend inference."
+      ],
+      "dependencies": [
+        "Outcome 1 brief scope",
+        "Current frontend dataset state inspection by Gemini after Codex contract definition"
+      ],
+      "acceptance_signals": [
+        "Dataset truth appears as trust context inside a valuable decision result.",
+        "No user has to inspect multiple panels to know which dataset powered the result.",
+        "The roadmap no longer asks Gemini to align every data consumer before a visible decision outcome exists."
+      ]
+    },
+    {
+      "recommendation_id": "rec-outcome-2-visual-evidence-board",
+      "title": "Turn ranked diagnostics into a Visual Evidence Board and Decision Map",
+      "summary": "After the brief, compose Phase 3 ranked observational diagnostics into a visual evidence board that shows the strongest quantified signals, covered levers, guardrails, segment coverage, limitations, and a bounded Decision Map of the current frame.",
+      "originating_agents": [
+        "decision-intelligence-specialist",
+        "product-ux-strategist",
+        "skeptic-qa-reviewer"
+      ],
+      "source_paths": [
+        "project_docs/active/contracts/decision_objects.md",
+        "project_docs/active/status/decision_intelligence_execution_status.md",
+        "user-provided exported workspace result evidence from 2026-05-22 request"
+      ],
+      "priority": "high",
+      "confidence": 0.84,
+      "implementation_timing": "next",
+      "rationale": "The app already has ranked diagnostics, but users need a visual decision outcome. An evidence board makes the diagnostic ranking legible and valuable without turning it into final recommendations.",
+      "impacted_areas": [
+        "workspace analysis contract",
+        "Decision Workspace view",
+        "AI Shell artifacts",
+        "export mapping",
+        "frontend browser acceptance"
+      ],
+      "frontend_implications": [
+        "Gemini should render quantified evidence as ranked cards or a board, with visual indicators for objective, levers, guardrails, segments, and limitations.",
+        "The Decision Map should show declared decision-frame relationships and evidence coverage, not causal effects.",
+        "The UI must not label evidence rank as recommendation priority."
+      ],
+      "backend_implications": [
+        "Codex should ensure ranked diagnostics expose brief-ready titles, quantified values where available, coverage metadata, and limitations.",
+        "Backend should provide enough structure for the Decision Map without requiring frontend inference."
+      ],
+      "contract_considerations": [
+        "Use ranked_diagnostics.semantic_coverage and data_sufficiency fields.",
+        "Add display-safe labels only if existing fields are too raw for a user-facing board.",
+        "Maintain observational_boundary."
+      ],
+      "testing_considerations": [
+        "Test that evidence board data includes at least one quantified value when the dataset supports it.",
+        "Test that low-sufficiency diagnostics are visibly caveated.",
+        "Test that evidence rank never changes allowed next actions into unsupported recommendation behavior."
+      ],
+      "risks": [
+        "A Decision Map may imply causality if labels are careless.",
+        "Evidence cards may regress into field dumps if not acceptance-gated."
+      ],
+      "dependencies": [
+        "Outcome 1 brief contract",
+        "Phase 3 ranked diagnostics"
+      ],
+      "acceptance_signals": [
+        "A user can visually identify the top evidence and why it matters to the objective.",
+        "The board shows which levers, guardrails, and segments are covered or missing.",
+        "The Decision Map is explicitly labeled as decision-frame structure and evidence coverage, not causal proof."
+      ]
+    },
+    {
+      "recommendation_id": "rec-outcome-3-bounded-scenario-compare",
+      "title": "Move bounded Scenario Compare ahead of full simulation",
+      "summary": "Add a visible scenario comparison workflow based on direct adjustments, guardrail impact, and explicit assumptions. This creates user-visible trade-off value without claiming causal simulation, Monte Carlo, optimization, or forecasts.",
+      "originating_agents": [
+        "decision-intelligence-specialist",
+        "data-ml-readiness-specialist",
+        "architecture-guardian",
+        "implementation-planner"
+      ],
+      "source_paths": [
+        "project_docs/active/contracts/decision_objects.md",
+        "project_docs/active/decision_intelligence/current/next_focus_execution_plan.md",
+        "project_docs/active/agent_council/outputs/compounding-phase-results/README.md"
+      ],
+      "priority": "high",
+      "confidence": 0.82,
+      "implementation_timing": "next",
+      "rationale": "Scenario comparison is one of the fastest ways to make Decision Intelligence feel valuable. The safe near-term path is sensitivity comparison using explicit direct adjustments and assumptions.",
+      "impacted_areas": [
+        "scenario service or scenario contract",
+        "decision workspace actions",
+        "AI Chat artifacts",
+        "Scenario Compare frontend view",
+        "PDF export mapping",
+        "tests for unsupported simulation requests"
+      ],
+      "frontend_implications": [
+        "Gemini should render side-by-side baseline and scenario cards with deltas, guardrail status, assumptions, and non-causal labels.",
+        "Scenario Compare should be visually distinct from final recommendations.",
+        "Controls should use clear inputs for lever adjustment and guardrail comparison."
+      ],
+      "backend_implications": [
+        "Codex should expose direct-adjustment scenario comparison from backend-owned calculations or existing scenario scaffold.",
+        "Backend must include assumptions and refusal states for unsupported Monte Carlo, causal simulation, and optimization requests.",
+        "Backend should compute guardrail pass/fail or unknown status where data supports it."
+      ],
+      "contract_considerations": [
+        "Reuse Scenario and DecisionScenarioPreview concepts.",
+        "Add comparison_summary and guardrail_impact only if needed and computed truthfully.",
+        "Do not call projected values forecasts unless a future validated forecasting contract exists."
+      ],
+      "testing_considerations": [
+        "Test baseline versus direct-adjustment scenario deltas.",
+        "Test guardrail impact rendering when thresholds are parsed and when thresholds are missing.",
+        "Test that Monte Carlo or optimization requests return readiness/refusal states rather than fake outputs."
+      ],
+      "risks": [
+        "Users may mistake sensitivity comparison for prediction.",
+        "Scenario controls can become misleading if they adjust outcome metrics directly without clear assumptions."
+      ],
+      "dependencies": [
+        "Outcome 1 brief",
+        "Dataset Trust Strip",
+        "Clear scenario assumption copy"
+      ],
+      "acceptance_signals": [
+        "A user can compare at least two bounded scenarios side by side and see quantified deltas.",
+        "The UI states that the comparison is direct-adjustment sensitivity analysis, not causal simulation or optimization.",
+        "Guardrail impact is visible when data and thresholds support it.",
+        "The scenario comparison can be included in an export-worthy artifact."
+      ]
+    },
+    {
+      "recommendation_id": "rec-export-pack-definition-of-done",
+      "title": "Make executive-ready export part of the Definition of Done",
+      "summary": "For brief, evidence, and scenario outcomes, completion requires a procedural export that a user would plausibly share: concise title, dataset context, quantified evidence, visual decision outcome, assumptions, caveats, and next allowed actions.",
+      "originating_agents": [
+        "product-ux-strategist",
+        "skeptic-qa-reviewer",
+        "implementation-planner"
+      ],
+      "source_paths": [
+        "project_docs/active/status/decision_intelligence_execution_status.md",
+        "user-provided exported workspace result evidence from 2026-05-22 request",
+        "project_docs/active/agent_council/outputs/compounding-phase-results/README.md"
+      ],
+      "priority": "high",
+      "confidence": 0.86,
+      "implementation_timing": "next",
+      "rationale": "The user specifically rejected an exported result that was not valuable. Export quality is the strongest forcing function against debug-like UI and low-synthesis output.",
+      "impacted_areas": [
+        "pdf report export utilities",
+        "AI Reporter",
+        "Decision Workspace export mapping",
+        "frontend export buttons",
+        "acceptance docs"
+      ],
+      "frontend_implications": [
+        "Gemini should ensure the same result hierarchy appears in UI and export.",
+        "Export actions should be available from the outcome surface, not hidden in generic artifact controls."
+      ],
+      "backend_implications": [
+        "Codex should provide export-ready fields so PDF generation does not summarize raw internals.",
+        "Backend should include limitations and assumptions as structured content."
+      ],
+      "contract_considerations": [
+        "Add export_sections only if existing brief and scenario objects cannot map cleanly.",
+        "Do not export unsupported capability promises."
+      ],
+      "testing_considerations": [
+        "Verify generated export includes quantified evidence and dataset trust context.",
+        "Reject exports that only contain readiness labels, repeated prompt text, or raw guardrail lists.",
+        "Run a focused browser/export acceptance path for outcome units."
+      ],
+      "risks": [
+        "Export verification can become time-consuming.",
+        "PDF polish may distract from backend synthesis if not scoped."
+      ],
+      "dependencies": [
+        "Existing procedural PDF export refactor",
+        "Outcome 1 brief contract"
+      ],
+      "acceptance_signals": [
+        "The exported artifact contains a clear business title, quantified evidence, dataset context, assumptions, and caveats.",
+        "The export can stand alone without the user needing to explain raw readiness fields.",
+        "The exported result is inspected as part of acceptance, not treated as a secondary nicety."
+      ]
+    },
+    {
+      "recommendation_id": "rec-advanced-readiness-gates",
+      "title": "Move advanced capability readiness into visible gates instead of hidden labels",
+      "summary": "Represent Monte Carlo, prediction, optimization, and final recommendation as visible locked or gated workflows with exact missing prerequisites. Do not implement Monte Carlo simulation until assumptions, distributions, validation strategy, and data sufficiency are in place.",
+      "originating_agents": [
+        "data-ml-readiness-specialist",
+        "architecture-guardian",
+        "skeptic-qa-reviewer"
+      ],
+      "source_paths": [
+        "project_docs/active/contracts/decision_objects.md",
+        "project_docs/active/decision_intelligence/current/next_focus_execution_plan.md",
+        "project_docs/active/status/decision_intelligence_execution_status.md"
+      ],
+      "priority": "medium",
+      "confidence": 0.8,
+      "implementation_timing": "later",
+      "rationale": "Readiness labels are low-value when dumped into results, but high-value when they explain why an advanced workflow is unavailable and what would unlock it.",
+      "impacted_areas": [
+        "capability_state contract",
+        "ML readiness diagnostics",
+        "advanced analysis UI gates",
+        "unsupported capability tests"
+      ],
+      "frontend_implications": [
+        "Gemini should show advanced workflows as gated cards only when they help the user understand next data requirements.",
+        "Locked states must be concise and actionable, not verbose capability matrices."
+      ],
+      "backend_implications": [
+        "Codex should define explicit prerequisites for Monte Carlo and predictive analysis before any runtime output exists.",
+        "Backend should continue refusing unsupported advanced requests."
+      ],
+      "contract_considerations": [
+        "Use capability_state and unsupported_capabilities as backend truth.",
+        "Future Monte Carlo readiness should include assumptions, distribution availability, row sufficiency, validation approach, leakage risk, and causal caveat fields."
+      ],
+      "testing_considerations": [
+        "Test unsupported Monte Carlo and optimization prompts.",
+        "Test readiness gates for missing target, missing lever distribution, insufficient rows, and leakage-prone features.",
+        "Test that gated advanced workflows do not appear as available actions."
+      ],
+      "risks": [
+        "Gated cards could still feel like more labels if they are not tied to high-value workflows.",
+        "Users may ask for Monte Carlo before prerequisites are implemented."
+      ],
+      "dependencies": [
+        "Outcome 3 Scenario Compare",
+        "Future ML readiness contract"
+      ],
+      "acceptance_signals": [
+        "Advanced analysis gates explain missing prerequisites in plain business language.",
+        "Unsupported capabilities remain visibly unavailable without dominating the main result.",
+        "No probabilistic simulation, optimization, or final recommendation is implied."
+      ]
+    },
+    {
+      "recommendation_id": "rec-update-docs-after-acceptance",
+      "title": "Update active docs to prevent old-roadmap resumption",
+      "summary": "After the user accepts this council result, update the active documentation so the next agent starts from the compounding-results roadmap and does not continue Phase 4 as a broad standalone dataset-contract handoff.",
+      "originating_agents": [
+        "implementation-planner",
+        "architecture-guardian",
+        "skeptic-qa-reviewer"
+      ],
+      "source_paths": [
+        "project_docs/INDEX.md",
+        "project_docs/active/README.md",
+        "project_docs/active/ai_hand_off/README.md",
+        "project_docs/active/agent_council/outputs/compounding-phase-results/README.md"
+      ],
+      "priority": "critical",
+      "confidence": 0.93,
+      "implementation_timing": "now",
+      "rationale": "The current docs still route agents to Phase 4 Canonical Active Dataset Contract as active next. If docs are not changed, future work will drift back into the roadmap the user has challenged.",
+      "impacted_areas": [
+        "project_docs/INDEX.md",
+        "project_docs/active/README.md",
+        "project_docs/active/status/decision_intelligence_execution_status.md",
+        "project_docs/active/decision_intelligence/current/next_focus_execution_plan.md",
+        "project_docs/active/ai_hand_off/README.md",
+        "project_docs/active/ai_hand_off/phase_4_gemini_frontend_canonical_active_dataset.md"
+      ],
+      "frontend_implications": [
+        "Gemini should receive a new handoff for Outcome 1 only after Codex defines the backend and contract truth.",
+        "The existing Phase 4 handoff should be marked superseded, narrowed, or paused."
+      ],
+      "backend_implications": [
+        "Codex should create the new outcome-focused plan and update status truth.",
+        "Codex should not ask Gemini to implement a broad frontend dataset alignment before the brief contract exists."
+      ],
+      "contract_considerations": [
+        "Docs should explain that dataset contract work remains an enabling trust layer.",
+        "Docs should preserve truthful capability boundaries and non-goals."
+      ],
+      "testing_considerations": [
+        "Doc updates should name the next acceptance checks and avoid stale checklist ambiguity.",
+        "Future agents should be able to identify the new first implementation unit from INDEX and active README."
+      ],
+      "risks": [
+        "Partial doc updates could create conflicting active truth.",
+        "Completed handoffs may be mistaken for active work if not clearly labeled."
+      ],
+      "dependencies": [
+        "User acceptance of the council recommendation",
+        "Codex doc coordination"
+      ],
+      "acceptance_signals": [
+        "INDEX and active README route the next agent to the compounding-results roadmap.",
+        "Status doc says Phase 4 standalone dataset contract has been superseded or narrowed.",
+        "AI handoff README no longer lists the old Phase 4 handoff as the active next frontend implementation without qualification."
+      ]
+    }
+  ],
+  "unresolved_questions": [
+    {
+      "question_id": "question-brief-data-source",
+      "question": "Should the first Executive Decision Brief be generated from existing workspace_analysis and ranked_diagnostics only, or should Codex add a thin dedicated brief synthesis service?",
+      "owner": "Codex",
+      "needed_before": "Outcome 1 backend implementation",
+      "impact": "Determines whether the first implementation is mostly contract normalization or a new backend synthesis path."
+    },
+    {
+      "question_id": "question-export-format",
+      "question": "Should acceptance require PDF only first, or also a shareable structured JSON or markdown-style executive brief export?",
+      "owner": "Codex with user decision",
+      "needed_before": "Outcome 1 export acceptance",
+      "impact": "Affects export scope and what artifact the user can immediately share."
+    },
+    {
+      "question_id": "question-direct-adjustment-scope",
+      "question": "For bounded Scenario Compare, should direct adjustments apply only to selected outcome metrics first, or to lever inputs when the data model can identify lever-to-metric relationships?",
+      "owner": "Codex",
+      "needed_before": "Outcome 3 scenario contract",
+      "impact": "Determines how conservative the first comparison is and how much risk there is of implying causality."
+    },
+    {
+      "question_id": "question-low-value-surface-retirement",
+      "question": "Which existing low-value readiness or diagnostic surfaces should be hidden, collapsed, or demoted after the new brief exists?",
+      "owner": "User with Codex review and Gemini implementation",
+      "needed_before": "Outcome 2 frontend cleanup",
+      "impact": "Affects whether the app continues to show old debug-heavy surfaces alongside the new outcome views."
+    }
+  ],
+  "risks": [
+    {
+      "risk_id": "risk-old-roadmap-drift",
+      "title": "Future agents resume Phase 4 unchanged",
+      "severity": "high",
+      "likelihood": "high",
+      "mitigation": "After user acceptance, update INDEX, active README, status, next_focus_execution_plan, and handoff README to route to the compounding outcome ladder.",
+      "owner": "Codex"
+    },
+    {
+      "risk_id": "risk-scenario-overclaim",
+      "title": "Scenario comparison is mistaken for causal simulation or forecast",
+      "severity": "high",
+      "likelihood": "medium",
+      "mitigation": "Use direct-adjustment sensitivity labels, explicit assumptions, guardrail impact, and refusal states for Monte Carlo, optimization, and causal claims.",
+      "owner": "Codex"
+    },
+    {
+      "risk_id": "risk-brief-becomes-diagnostics-dump",
+      "title": "Executive Decision Brief repeats the current low-value output pattern",
+      "severity": "critical",
+      "likelihood": "medium",
+      "mitigation": "Acceptance must fail if the brief lacks quantified evidence, repeats the prompt as filler, or leads with readiness labels instead of business findings.",
+      "owner": "Skeptic/QA Reviewer"
+    },
+    {
+      "risk_id": "risk-frontend-infers-backend-truth",
+      "title": "Frontend presentation invents synthesis not present in backend contracts",
+      "severity": "high",
+      "likelihood": "medium",
+      "mitigation": "Codex must define brief-ready and scenario-ready backend contract fields before Gemini implements the visible surfaces.",
+      "owner": "Architecture Guardian"
+    },
+    {
+      "risk_id": "risk-first-outcome-too-broad",
+      "title": "Outcome 1 expands into an all-surface rewrite",
+      "severity": "medium",
+      "likelihood": "medium",
+      "mitigation": "Limit Outcome 1 to one prompt-to-brief-to-export vertical path plus the minimal Dataset Trust Strip needed for that path.",
+      "owner": "Implementation Planner"
+    }
+  ],
+  "impacted_codebase_areas": [
+    {
+      "area": "Decision Intelligence planning docs",
+      "path_patterns": [
+        "project_docs/active/decision_intelligence/current/next_focus_execution_plan.md",
+        "project_docs/active/status/decision_intelligence_execution_status.md",
+        "project_docs/INDEX.md",
+        "project_docs/active/README.md"
+      ],
+      "why_it_matters": "These files currently route the project to Phase 4 canonical dataset work and must be updated if this council result is accepted.",
+      "change_type": "documentation"
+    },
+    {
+      "area": "Codex/Gemini handoffs",
+      "path_patterns": [
+        "project_docs/active/ai_hand_off/README.md",
+        "project_docs/active/ai_hand_off/phase_4_gemini_frontend_canonical_active_dataset.md"
+      ],
+      "why_it_matters": "The active Phase 4 frontend handoff should be superseded, paused, or narrowed into Dataset Trust after Codex defines Outcome 1.",
+      "change_type": "documentation"
+    },
+    {
+      "area": "Decision object contracts",
+      "path_patterns": [
+        "project_docs/active/contracts/decision_objects.md"
+      ],
+      "why_it_matters": "Existing DecisionBrief, DecisionSignal, Scenario, DecisionScenarioPreview, Dataset Summary, readiness, and ranked diagnostics contracts are the likely foundation for visible outcomes.",
+      "change_type": "contract"
+    },
+    {
+      "area": "Backend decision services",
+      "path_patterns": [
+        "backend/services/decision_workspace_service.py",
+        "backend/decision_engine/chat_service.py",
+        "tests/test_decision_*.py"
+      ],
+      "why_it_matters": "Codex likely needs to synthesize brief-ready, evidence-ready, and scenario-ready backend outputs before Gemini renders visible outcomes.",
+      "change_type": "backend"
+    },
+    {
+      "area": "Frontend Decision Intelligence surfaces",
+      "path_patterns": [
+        "frontend/frontend/src/features/ai/AIShell.jsx",
+        "frontend/frontend/src/features/business/decision/DecisionWorkspaceView.jsx",
+        "frontend/frontend/src/components/insights/DataPane.jsx"
+      ],
+      "why_it_matters": "Gemini will need to render the brief, evidence board, dataset trust strip, scenario compare, and advanced readiness gates after backend contract stabilization.",
+      "change_type": "frontend"
+    },
+    {
+      "area": "Export pipeline",
+      "path_patterns": [
+        "frontend/frontend/src/features/ai/AIReporter.jsx",
+        "frontend/frontend/src/utils/pdfReportExport.js",
+        "frontend/frontend/src/utils/decisionPdfExport.js"
+      ],
+      "why_it_matters": "Executive-ready export is now part of acceptance, not an optional polish step.",
+      "change_type": "frontend"
+    }
+  ],
+  "frontend_implications": [
+    "Gemini should not continue the broad Phase 4 canonical active dataset handoff unchanged after this council is accepted.",
+    "Future Gemini handoffs must name the visible result, not only fields to render.",
+    "Readiness, capability boundaries, and guardrails should be summarized as trust context, caveats, disabled advanced actions, or blockers rather than dominating the result.",
+    "Decision Brief, Evidence Board, Scenario Compare, and exports should share the same hierarchy so the product feels like a coherent workflow.",
+    "Every Gemini implementation must include a browser-visible acceptance path and, when applicable, an export verification path."
+  ],
+  "backend_implications": [
+    "Codex should build synthesized outcome contracts rather than only hidden additive metadata.",
+    "The first backend task should produce brief-ready structure from corrected decision frame, ranked diagnostics, dataset summary, assumptions, limitations, and allowed actions.",
+    "Dataset truth should be scoped first to the decision result being generated, not all app surfaces at once.",
+    "Scenario Compare should start as backend-owned direct-adjustment sensitivity with assumptions and guardrail impact, not Monte Carlo or optimization.",
+    "Unsupported simulation, optimization, autonomous decisioning, and final recommendation requests must continue to be refused or gated truthfully."
+  ],
+  "contract_considerations": [
+    "Prefer reusing DecisionBrief, DecisionSignal, Scenario, DecisionScenarioPreview, Dataset Summary, readiness, capability_state, and ranked_diagnostics before adding new schemas.",
+    "New fields should be additive, display-ready, and traceable to existing diagnostics or dataset state.",
+    "Brief outputs must include quantified evidence where available, limitations, assumptions, dataset context, and truth_boundary.",
+    "Scenario outputs must label direct adjustments as sensitivity analysis and include assumptions.",
+    "Monte Carlo readiness should be represented as gated prerequisites, not runtime simulation output."
+  ],
+  "testing_considerations": [
+    "Each outcome unit needs at least three acceptance prompts: complete decision frame, incomplete or blocked frame, and unsupported advanced-capability request.",
+    "Tests must verify visible-value data, not just field presence: quantified evidence, dataset context, caveats, and export-ready sections.",
+    "Export acceptance must reject repeated prompt dumps, generic readiness pages, and raw field lists without synthesis.",
+    "Scenario tests must verify direct-adjustment deltas, guardrail impact where possible, and non-causal assumption labels.",
+    "Browser verification should focus on one end-to-end visible outcome path rather than broad surface scans."
+  ],
+  "implementation_priority": {
+    "top_priority_ids": [
+      "rec-replace-phases-with-outcome-ladder",
+      "rec-outcome-1-executive-decision-brief",
+      "rec-narrow-phase-4-into-dataset-trust",
+      "rec-update-docs-after-acceptance"
+    ],
+    "deferred_ids": [
+      "rec-outcome-2-visual-evidence-board",
+      "rec-outcome-3-bounded-scenario-compare",
+      "rec-export-pack-definition-of-done",
+      "rec-advanced-readiness-gates"
+    ],
+    "rationale": "The immediate fix is to stop the old roadmap from driving another low-visible-value slice, then implement a thin vertical Decision Brief with Dataset Trust and export acceptance. Evidence Board and Scenario Compare are high-value next steps, while Monte Carlo and advanced readiness remain bounded until prerequisites are explicit."
+  },
+  "suggested_implementation_phases": [
+    {
+      "phase_id": "outcome-0-roadmap-reset",
+      "title": "Roadmap Reset To Outcome Ladder",
+      "owner": "Codex",
+      "objective": "Supersede the microscopic phase roadmap and create the active compounding-results plan.",
+      "recommendation_ids": [
+        "rec-replace-phases-with-outcome-ladder",
+        "rec-update-docs-after-acceptance"
+      ],
+      "entry_criteria": [
+        "User accepts or directs Codex to apply this emergency council result.",
+        "Codex confirms active docs still route to old Phase 4 dataset-contract work."
+      ],
+      "exit_criteria": [
+        "Active docs route future agents to the compounding outcome ladder.",
+        "Old Phase 4 canonical active dataset handoff is marked superseded, paused, or narrowed.",
+        "Next Codex task is Outcome 1 Executive Decision Brief with Dataset Trust."
+      ],
+      "validation_plan": [
+        "Read INDEX, active README, status, next focus plan, and handoff README after edits to confirm no conflicting active-next instruction remains.",
+        "Confirm docs preserve Codex/Gemini ownership and truthful capability boundaries."
+      ]
+    },
+    {
+      "phase_id": "outcome-1-executive-decision-brief",
+      "title": "Executive Decision Brief With Dataset Trust",
+      "owner": "Codex backend and contract first, then Gemini frontend",
+      "objective": "Create the first visible compounding result: a prompt-first decision brief with quantified evidence, dataset trust, limitations, allowed next actions, and export-ready structure.",
+      "recommendation_ids": [
+        "rec-outcome-1-executive-decision-brief",
+        "rec-narrow-phase-4-into-dataset-trust",
+        "rec-export-pack-definition-of-done"
+      ],
+      "entry_criteria": [
+        "Roadmap reset docs are active.",
+        "Codex identifies the minimal backend contract or service changes needed for brief-ready output.",
+        "Existing Phase 3 ranked diagnostics and dataset summary behavior are available."
+      ],
+      "exit_criteria": [
+        "Backend produces a brief-ready object with business question, objective, levers, guardrails, dataset trust, quantified evidence, limitations, assumptions, truth boundary, and allowed next actions.",
+        "Gemini renders the brief as a primary user-facing result.",
+        "A procedural export contains the same synthesized value without raw prompt repetition or readiness-label dumping.",
+        "Unsupported simulation and final-recommendation prompts remain truthful and bounded."
+      ],
+      "validation_plan": [
+        "Run focused backend tests for complete, blocked, and unsupported prompts.",
+        "Run frontend build after Gemini implementation.",
+        "Run one browser flow from prompt to brief to export.",
+        "Inspect export output for quantified evidence, dataset context, assumptions, and caveats."
+      ]
+    },
+    {
+      "phase_id": "outcome-2-visual-evidence-board",
+      "title": "Visual Evidence Board And Decision Map",
+      "owner": "Codex contract first, then Gemini frontend",
+      "objective": "Turn ranked observational diagnostics into a visual evidence board and bounded Decision Map that helps users understand what evidence supports the decision frame.",
+      "recommendation_ids": [
+        "rec-outcome-2-visual-evidence-board"
+      ],
+      "entry_criteria": [
+        "Outcome 1 brief is visible and exportable.",
+        "Backend ranked diagnostics include sufficient quantified evidence and coverage metadata."
+      ],
+      "exit_criteria": [
+        "Evidence Board shows ranked quantified signals, relevance, evidence strength, covered levers, guardrails, segments, data sufficiency, and limitations.",
+        "Decision Map shows objective, levers, guardrails, segments, assumptions, and evidence coverage without causal claims.",
+        "Export can include the evidence board summary."
+      ],
+      "validation_plan": [
+        "Test evidence-board payload shape from backend diagnostics.",
+        "Run browser verification that evidence cards are not raw field dumps.",
+        "Verify Decision Map labeling avoids causal, optimization, and recommendation claims."
+      ]
+    },
+    {
+      "phase_id": "outcome-3-bounded-scenario-compare",
+      "title": "Bounded Scenario Compare",
+      "owner": "Codex backend first, then Gemini frontend",
+      "objective": "Provide side-by-side direct-adjustment sensitivity comparison with assumptions, quantified deltas, dataset trust, and guardrail impact where available.",
+      "recommendation_ids": [
+        "rec-outcome-3-bounded-scenario-compare",
+        "rec-export-pack-definition-of-done"
+      ],
+      "entry_criteria": [
+        "Outcome 1 brief and Dataset Trust Strip are working.",
+        "Codex defines the scenario comparison contract and non-causal copy boundaries.",
+        "User accepts direct-adjustment sensitivity as the first scenario mode."
+      ],
+      "exit_criteria": [
+        "Scenario Compare renders baseline and at least one alternative with quantified deltas.",
+        "Assumptions and non-causal boundaries are visible.",
+        "Guardrail pass, fail, or unknown impact is visible where thresholds and data support it.",
+        "Monte Carlo, optimization, and causal simulation requests are refused or gated."
+      ],
+      "validation_plan": [
+        "Run backend tests for scenario delta calculation, guardrail impact, missing thresholds, and unsupported Monte Carlo requests.",
+        "Run frontend build and one browser scenario flow.",
+        "Verify export includes scenario comparison with assumptions and caveats."
+      ]
+    },
+    {
+      "phase_id": "outcome-4-advanced-analysis-readiness",
+      "title": "Advanced Analysis Readiness Gates",
+      "owner": "Codex backend and contract first, then Gemini frontend",
+      "objective": "Turn advanced capability readiness into concise visible gates for Monte Carlo, prediction, optimization, and final recommendation without implementing unsupported runtime capability.",
+      "recommendation_ids": [
+        "rec-advanced-readiness-gates"
+      ],
+      "entry_criteria": [
+        "Scenario Compare has shipped as bounded sensitivity analysis.",
+        "Codex defines concrete prerequisites for Monte Carlo and predictive analysis.",
+        "User explicitly wants advanced-readiness planning surfaced."
+      ],
+      "exit_criteria": [
+        "Advanced gates explain what is missing before Monte Carlo, prediction, optimization, or final recommendation can be supported.",
+        "Unsupported capabilities remain unavailable actions.",
+        "No probabilistic or optimized output is generated."
+      ],
+      "validation_plan": [
+        "Run unsupported capability prompt tests.",
+        "Run readiness tests for missing target, insufficient rows, missing distributions, leakage-prone features, and absent validation strategy.",
+        "Verify frontend gate copy is concise and does not dominate completed brief or scenario results."
+      ]
+    }
+  ],
+  "final_synthesis_summary": {
+    "executive_summary": "The council rejects continuing the current microscopic phase roadmap as the organizing model. The next work should not be broad Phase 4 dataset-contract alignment. Dataset truth remains important, but only as a visible trust layer inside user-valued outcomes. The immediate roadmap should produce an Executive Decision Brief with Dataset Trust and export acceptance, then compound into a Visual Evidence Board, bounded Scenario Compare, executive-ready export pack, and advanced capability readiness gates. Every unit must create an obvious result a user can see, understand, export, and value.",
+    "strongest_proposal": "Outcome 1: Executive Decision Brief with Dataset Trust. It converts completed backend and frontend infrastructure into the first result the user is likely to recognize as business value: quantified evidence, decision frame, dataset trust, assumptions, caveats, allowed next actions, and exportable output.",
+    "main_tradeoff": "The project must preserve truthful capability boundaries while becoming much more visibly valuable. That means moving scenario comparison up only as direct-adjustment sensitivity analysis, not Monte Carlo or causal simulation, and narrowing dataset work so it supports trust in a decision result instead of becoming another hidden infrastructure phase.",
+    "decision_for_next_agent": "Do not start the old Phase 4 canonical active dataset frontend handoff unchanged. First update the active docs after user acceptance, then have Codex define Outcome 1 backend and contract truth for an Executive Decision Brief with Dataset Trust. Gemini should receive a new frontend handoff only after that contract is stable.",
+    "non_goals": [
+      "Do not implement fake Monte Carlo simulation.",
+      "Do not imply optimization, autonomous decisioning, causal inference, prediction, or final recommendations.",
+      "Do not continue adding hidden contract fields without a visible result.",
+      "Do not ask Gemini to infer backend synthesis in the frontend.",
+      "Do not treat build success, docs, or raw field rendering as completion."
+    ],
+    "handoff_notes": "If accepted, Codex should create or update the compounding-results roadmap docs, mark the old Phase 4 handoff as superseded or narrowed, and write a new Outcome 1 plan. The first Gemini prompt should be short and focused on rendering the backend-provided brief, dataset trust strip, and export path, not on broad app-wide dataset state refactoring."
+  },
+  "metadata": {
+    "created_by": "Codex emergency Agent Council simulation",
+    "schema_path": "project_docs/active/agent_council/council_output_schema.json",
+    "validator_path": "project_docs/active/agent_council/validate_council_json.py"
+  }
+}

--- a/project_docs/active/agent_council/outputs/compounding-phase-results/README.md
+++ b/project_docs/active/agent_council/outputs/compounding-phase-results/README.md
@@ -1,0 +1,68 @@
+# Compounding Phase Results Council
+
+## Purpose
+
+This Agent Council topic exists because the current Decision Intelligence implementation plan is producing too many microscopic, hard-to-see slices. Codex and Gemini are shipping backend contracts, frontend renderers, docs, and tests, but the user often cannot easily tell what changed in the product or whether thousands of lines of work were worth it.
+
+The council must restructure the current active plan into a different execution model where each section produces obvious, compounding product results.
+
+## User Problem
+
+The user does not want to keep fighting prompts, phase labels, hidden contracts, and narrow acceptance checks just to see whether a feature exists.
+
+The current flow has too much planning and too little visible payoff per implementation slice. Each step may be technically valid, but the result is not obvious enough in the app.
+
+## Council Question
+
+Given the current active documentation and the app direction, how should the Decision Intelligence roadmap be restructured so every future unit of work produces compounding, visible product results?
+
+The council should not simply rename phases. It should propose a different model for organizing work, acceptance, demos, prompts, UI visibility, backend contracts, Gemini handoffs, and user-facing verification.
+
+## Sources To Review
+
+Required:
+
+`project_docs/INDEX.md`
+
+`project_docs/active/README.md`
+
+`project_docs/active/status/decision_intelligence_execution_status.md`
+
+`project_docs/active/rules/CODEX_FRONTEND_GUARDRAIL_READ_FIRST.md`
+
+`project_docs/active/decision_intelligence/current/next_focus_execution_plan.md`
+
+`project_docs/active/ai_hand_off/README.md`
+
+Optional only if needed:
+
+`project_docs/active/contracts/decision_objects.md`
+
+`project_docs/active/ai_hand_off/phase_4_gemini_frontend_canonical_active_dataset.md`
+
+## What The Council Must Produce
+
+The council must produce a strict JSON artifact matching `project_docs/active/agent_council/council_output_schema.json`.
+
+The final recommendations must include:
+
+- A new work organization model that does not depend on microscopic phase labels.
+- A rule that every implementation unit must produce an obvious user-visible result.
+- A rule that every backend contract slice must include a demo path or visible frontend proof before it is considered done.
+- A way to keep Codex and Gemini ownership intact while improving visible outcomes.
+- A proposed replacement for the current Phase 4 path if needed, while preserving the app direction toward trustworthy Decision Intelligence.
+- Acceptance criteria focused on what the user can see and verify in the app, not only tests, docs, or hidden contract fields.
+- A recommendation for how docs should change after the council result is accepted.
+
+## Boundaries
+
+Do not recommend fake simulation, fake optimization, fake causal claims, autonomous decisioning, or final recommendations.
+
+Do not discard useful completed work. The council may reorganize the path forward, but it should preserve the direction of the app: trustworthy Decision Intelligence, clear dataset truth, semantic grounding, observational analysis, readiness diagnostics, and eventually responsible advanced decision support.
+
+Do not break the Codex/Gemini ownership model. Codex remains backend/contracts/docs/review coordinator. Gemini remains frontend implementer unless the user explicitly authorizes Codex frontend edits.
+
+## Paste-Ready Council Prompt
+
+Run an emergency Agent Council for AI_Tool focused on compounding phase results. Read `project_docs/INDEX.md`, `project_docs/active/README.md`, `project_docs/active/status/decision_intelligence_execution_status.md`, `project_docs/active/rules/CODEX_FRONTEND_GUARDRAIL_READ_FIRST.md`, `project_docs/active/decision_intelligence/current/next_focus_execution_plan.md`, `project_docs/active/ai_hand_off/README.md`, and `project_docs/active/agent_council/outputs/compounding-phase-results/README.md`. The current plan is not working for the user: Codex and Gemini are shipping many technical slices, but the results are too microscopic, too hard to see, and too dependent on fighting prompts or reading docs. Restructure the roadmap into a different model where every unit of work creates obvious, compounding product results. Preserve the app direction toward trustworthy Decision Intelligence and preserve the Codex/Gemini ownership split, but challenge the current phase structure, acceptance criteria, handoff style, demo requirements, and documentation flow. Return JSON only, matching `project_docs/active/agent_council/council_output_schema.json`.
+

--- a/project_docs/active/ai_hand_off/README.md
+++ b/project_docs/active/ai_hand_off/README.md
@@ -10,6 +10,8 @@ Gemini owns frontend implementation. Gemini must do React, CSS, UI rendering, br
 
 | Handoff | Owner | Status |
 | --- | --- | --- |
+| `phase_4_gemini_frontend_canonical_active_dataset.md` | Gemini frontend | Active next |
+| `phase_3_gemini_frontend_correction_and_ranked_evidence.md` | Gemini frontend | Complete |
 | `phase_2_5_gemini_frontend_segment_dimensions.md` | Gemini frontend | Complete |
 
 ## Rules
@@ -21,6 +23,18 @@ Gemini must not change backend files. If Gemini finds missing backend behavior, 
 Gemini must preserve existing features and workflows. Do not hide, remove, downgrade, disable, de-scope, or retire visible capability unless the user explicitly approves it.
 
 Codex has final say on sequencing and acceptance. Gemini implements the frontend slice described in the handoff, verifies it, and updates active status docs truthfully.
+
+## Codex Review Budget
+
+When Codex reviews Gemini frontend work, keep the pass narrow:
+
+- Read the active handoff and status truth.
+- Inspect only changed frontend files named by the handoff or Gemini summary.
+- Use targeted searches for the specific contract fields under review.
+- Do not rerun the frontend build when Gemini already reported a successful build unless Codex finds a likely syntax/import defect or the user asks for build verification.
+- Do not turn acceptance review into a broad source audit or browser QA pass unless the handoff explicitly requires browser evidence and Gemini did not provide it.
+
+The output should be short: acceptance label first, only actionable findings, then a concise Gemini prompt if a fix is needed.
 
 ## Historical Examples
 

--- a/project_docs/active/ai_hand_off/phase_3_gemini_frontend_correction_and_ranked_evidence.md
+++ b/project_docs/active/ai_hand_off/phase_3_gemini_frontend_correction_and_ranked_evidence.md
@@ -1,0 +1,91 @@
+# Phase 3 Gemini Frontend Handoff: Correction And Ranked Evidence
+
+Owner: Gemini frontend
+
+Status: Complete
+
+## Backend Truth
+
+Codex completed the Phase 3 backend slice on May 22, 2026. Existing endpoint names, existing action IDs, artifact types, readiness fields, and the `observational_analysis_only` boundary were preserved.
+
+Decision frame corrections are deterministic and explicit. Backend service callers can use the correction service directly, and the Decision Chat action route can apply a correction payload through the existing `draft_workspace` action. The response can include additive `correction_result`, `trace`, corrected `decision_workspace`, recomputed `decision_readiness`, recomputed `allowed_next_actions`, and corrected session state.
+
+Workspace analysis now includes additive `workspace_analysis.ranked_diagnostics` and `workspace_analysis.observational_boundary` while preserving existing `scoped_diagnostics` and `legacy_diagnostics`.
+
+## Current Frontend Truth
+
+Gemini has completed the Phase 3 implementation, including correction rendering and ranked observational diagnostics.
+
+The correction panel is integrated into the existing `workspace_preview` renderer.
+
+The ranked evidence renderer follows the exact backend `semantic_coverage` shape.
+
+All invalid plain React style shorthand keys have been replaced with valid CSS properties. The frontend is contract-adherent and verified with build.
+
+## Files To Inspect
+
+Render correction results and ranked observational diagnostics without adding simulation, optimization, causal, autonomous-decisioning, or final-recommendation language.
+
+Inspect these actual current frontend paths:
+
+`frontend/frontend/src/features/ai/AIShell.jsx`
+
+`frontend/frontend/src/features/business/decision/DecisionWorkspaceView.jsx`
+
+`frontend/frontend/src/features/business/decision/DecisionWorkspace.css`
+
+If shared artifact rendering utilities exist for `workspace_analysis_summary`, use the existing local pattern instead of creating a separate one-off surface.
+
+## Exact Backend Shapes
+
+Correction fields arrive on a `workspace_preview` artifact:
+
+`artifact.type`
+
+Current value: `workspace_preview`
+
+`artifact.correction_result`
+
+Object with `status`, `correction_type`, `target_path`, `summary`, `previous_value`, `new_value`, `affected_readiness_fields`, `readiness_state`, and `allowed_next_actions`.
+
+`artifact.trace`
+
+Object with `source`, `timestamp`, `correction_type`, `target_path`, `reason`, `semantic_confidence`, `warnings`, `unresolved_mappings`, and `observational_boundary`.
+
+Ranked diagnostics arrive on `workspace_analysis_summary` content:
+
+`content.ranked_diagnostics[]`
+
+Each item includes `evidence_rank`, `relevance_score`, `evidence_strength`, `semantic_coverage`, `data_sufficiency`, `limitations`, `observational_boundary`, and `source_diagnostic`.
+
+`semantic_coverage`
+
+Exact backend keys are `objective`, `temporal`, `levers`, `guardrails`, `segments`, and `semantic_confidences`.
+
+`objective` and `temporal` are booleans.
+
+`levers`, `guardrails`, and `segments` are arrays. Items can be objects, not strings. Render a readable label from `label`, `lever_id`, `constraint_id`, `segment_id`, `dimension_ref.label`, `dimension_ref.field`, or fallback JSON.
+
+`semantic_confidences` is an array of numbers. Render each numeric value directly as a percent. Do not use `Object.entries` on it.
+
+Do not read `semantic_coverage.covers_objective`. Do not read `semantic_coverage.temporal_grain`. Those are not backend contract fields.
+
+The frontend should continue to respect backend-owned `decision_readiness`, `allowed_next_actions`, `blocked_state`, `capability_state`, and `unsupported_capabilities`.
+
+## Acceptance Behavior
+
+When a correction response is rendered, the user can see what changed, the target path, the previous and new value in a readable form, the updated readiness state, and any trace warnings. The corrected workspace state must be the state used by follow-up analysis and action rendering.
+
+When workspace analysis is rendered, ranked diagnostics appear as observational evidence ranked by diagnostic relevance. The UI must make clear that the ranking is not a recommended action order and is not simulation, optimization, causal impact, autonomous decisioning, or a final recommendation.
+
+Existing scoped diagnostics, legacy diagnostics, blockers, assumptions, open workspace, and readiness behavior must keep working.
+
+## Verification
+
+Run the frontend build and one focused browser flow that starts from a decision prompt, applies or inspects a corrected workspace response if the UI exposes correction controls, runs Analyze workspace, and verifies ranked diagnostics are visible with the observational-only boundary. If correction controls are not yet exposed, verify the rendering using a mocked or fixture-backed response consistent with the contract.
+
+Update `project_docs/active/status/decision_intelligence_execution_status.md` with the exact frontend files changed, build result, browser verification result, and any remaining caveats.
+
+## Gemini CLI Prompt
+
+No active Gemini prompt remains for this completed Phase 3 handoff. Use `project_docs/active/ai_hand_off/phase_4_gemini_frontend_canonical_active_dataset.md` for the next frontend slice.

--- a/project_docs/active/ai_hand_off/phase_4_gemini_frontend_canonical_active_dataset.md
+++ b/project_docs/active/ai_hand_off/phase_4_gemini_frontend_canonical_active_dataset.md
@@ -1,0 +1,79 @@
+# Phase 4 Gemini Frontend Handoff: Canonical Active Dataset
+
+Owner: Gemini frontend
+
+Status: Active next
+
+## Current Truth
+
+Phase 3 correction results and ranked observational evidence are complete. The next roadmap item is Phase 4: Canonical Active Dataset Contract.
+
+This is not the completed historical Phase 4 chat-contract work. This Phase 4 is the post-Phase-3 dataset-truth alignment slice from `project_docs/active/decision_intelligence/current/next_focus_execution_plan.md`.
+
+## Goal
+
+Make the app show and use one coherent active dataset truth across major surfaces: AI Chat, Decisions, charts, dashboards, workflows, filters, cleaning, uploads, and semantic model consumers.
+
+The user should be able to tell which dataset is active, where it came from, whether it is cleaned/transformed, and whether a surface is using the global active dataset or an explicit override.
+
+## Files To Inspect First
+
+Read the docs first:
+
+`project_docs/INDEX.md`
+
+`project_docs/active/README.md`
+
+`project_docs/active/status/decision_intelligence_execution_status.md`
+
+`project_docs/active/decision_intelligence/current/next_focus_execution_plan.md`
+
+Then inspect frontend state and dataset consumers. Likely starting points include:
+
+`frontend/frontend/src/App.jsx`
+
+`frontend/frontend/src/components/insights/DataPane.jsx`
+
+`frontend/frontend/src/features/ai/AIShell.jsx`
+
+`frontend/frontend/src/features/business/decision/DecisionWorkspaceView.jsx`
+
+`frontend/frontend/src/components/visualization/ChartPanel.jsx`
+
+Use targeted searches for active dataset, selected dataset, uploaded data, cleaned data, semantic model, chart data, dashboard data, and workflow data before editing.
+
+## Implementation Boundaries
+
+Do not change backend files unless the user explicitly authorizes it.
+
+Do not add simulation, optimization, causal claims, autonomous decisions, or final recommendations.
+
+Do not rewrite the app shell. This is a state and visibility alignment slice.
+
+Preserve existing AI Chat, Decisions, charts, dashboards, workflows, cleaning, uploads, and semantic model behavior.
+
+If a backend contract is missing, document the gap and stop for Codex review instead of inventing a backend API.
+
+## Acceptance Behavior
+
+There is a clear active dataset identity visible where decisions or analysis depend on data.
+
+Major surfaces use the same active dataset unless the UI clearly marks an explicit override.
+
+Dataset metadata should include source, dataset ID where available, row count, column count, and transform or cleaning state where available.
+
+Changing the active dataset should not silently leave AI Chat, Decisions, charts, dashboards, workflows, filters, cleaning, uploads, or semantic model consumers on stale data.
+
+## Verification
+
+Run `git diff --check`.
+
+Run `npm --prefix frontend\frontend run build`.
+
+Perform one focused browser flow that changes or confirms the active dataset and verifies that at least AI Chat, Decisions, and one visual/data surface display or consume the same active dataset truth.
+
+Update `project_docs/active/status/decision_intelligence_execution_status.md` truthfully with files changed, verification performed, and any remaining backend-contract gaps.
+
+## Gemini CLI Prompt
+
+Start Phase 4 Canonical Active Dataset frontend work. Read `project_docs/INDEX.md`, `project_docs/active/README.md`, `project_docs/active/status/decision_intelligence_execution_status.md`, `project_docs/active/decision_intelligence/current/next_focus_execution_plan.md`, and `project_docs/active/ai_hand_off/phase_4_gemini_frontend_canonical_active_dataset.md` first. Do not change backend files. Inspect current frontend dataset state and consumers, then implement one coherent active dataset truth across AI Chat, Decisions, charts, dashboards, workflows, filters, cleaning, uploads, and semantic model consumers where the current frontend state supports it. Show dataset source, ID where available, row count, column count, and cleaning/transform state where available. Preserve existing behavior and clearly mark any explicit dataset override. If a backend contract is missing, document the gap and stop for Codex review instead of inventing an API. Run `git diff --check` and `npm --prefix frontend\frontend run build`, do one focused browser flow, and update the active status doc truthfully.

--- a/project_docs/active/contracts/decision_objects.md
+++ b/project_docs/active/contracts/decision_objects.md
@@ -158,6 +158,47 @@ Prompt-first guardrail conditions keep the existing `operator`, `value`, `second
 | --- | --- | --- | --- |
 | `value_status` | `string \| null` | No | `parsed` when a numeric threshold was preserved, `not_specified` when the prompt gave a qualitative guardrail, or `unparsed` when threshold language was present but no numeric value could be parsed. Hard guardrails with `value_status: "unparsed"` are not analysis-ready. |
 
+### Decision Frame Correction
+
+Phase 3 adds deterministic backend-owned correction behavior for an existing draft workspace. The current action-route integration preserves existing endpoint names and action IDs by applying correction payloads through the existing Decision Chat action endpoint when `action` is `draft_workspace`. Backend service callers may also use the workspace correction service directly. Corrections are explicit; the backend does not mutate arbitrary workspace fields from free-form text.
+
+Correction request payload fields:
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `correction_type` | `string` | Yes | `objective_metric`, `objective_direction`, `time_horizon`, `lever_binding`, `lever_controllability`, `guardrail_binding`, `guardrail_condition`, `segment_dimension`, or `remove_mapping` |
+| `target_path` | `string` | Yes | Stable object path such as `decision_scope.objective.metric_ref`, `decision_scope.levers[0].binding`, `decision_scope.constraints[0].condition`, or `decision_scope.segment_dimensions` |
+| `replacement` | `object \| boolean \| string \| number \| null` | Conditional | Required except for `remove_mapping`. The shape depends on correction type and may contain metric, dimension, field, condition, horizon, direction, or controllability values. |
+| `reason` | `string \| null` | No | Optional user or system reason for auditability. |
+
+Correction response fields:
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `correction_result` | `object` | Yes | Includes `status`, `correction_type`, `target_path`, `summary`, `previous_value`, `new_value`, `affected_readiness_fields`, `readiness_state`, and `allowed_next_actions` |
+| `decision_workspace` | `object` | Yes | Updated workspace with recomputed `decision_scope`, `scoped_context`, `assumptions`, `unknowns`, `readiness`, `status`, and additive `correction_history` |
+| `decision_readiness` | `Decision Readiness State` | Yes | Recomputed readiness and capability truth after the correction |
+| `allowed_next_actions` | `string[]` | Yes | Recomputed backend-approved action IDs. Existing IDs are preserved. |
+| `trace` | `object` | Yes | Includes correction source, timestamp, target path, semantic confidence when available, warnings, unresolved mapping placeholders, and `observational_boundary: "observational_analysis_only"` |
+
+The action-route response may include additive top-level `correction_result` and `trace` fields and a corrected workspace preview artifact. Existing action IDs, artifact types, readiness fields, and session-state carry-forward remain compatible.
+
+### Ranked Observational Diagnostics
+
+Phase 3 strengthens workspace analysis with `workspace_analysis.ranked_diagnostics` while preserving existing `scoped_diagnostics` and `legacy_diagnostics`. Ranking is diagnostic relevance to the current decision frame only. It is not a recommended action order, optimization result, simulation, causal claim, or final recommendation.
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `workspace_analysis.observational_boundary` | `string` | Yes | Current value is `observational_analysis_only` |
+| `workspace_analysis.ranked_diagnostics` | `object[]` | Yes | Ordered diagnostic evidence derived from the same scoped workspace analysis |
+| `evidence_rank` | `integer` | Yes | 1-based rank within the analysis response |
+| `relevance_score` | `number` | Yes | `0.0` to `1.0` score based on frame role relevance, evidence availability, and readiness |
+| `evidence_strength` | `string` | Yes | `strong`, `moderate`, `weak`, or `insufficient` |
+| `semantic_coverage` | `object` | Yes | Shows whether the diagnostic covers the objective and lists covered levers, guardrails, segments, temporal context, and semantic confidences |
+| `data_sufficiency` | `object` | Yes | Includes sufficiency status, row count when available, and whether a period comparison exists |
+| `limitations` | `string[]` | Yes | Caveats, unresolved or weak semantic evidence, readiness limitations, and the explicit diagnostic-only ranking boundary |
+| `source_diagnostic` | `object` | Yes | Original scoped diagnostic object for compatibility and traceability |
+
 ### Time Context
 
 | Field | Type | Required | Notes |

--- a/project_docs/active/decision_intelligence/README.md
+++ b/project_docs/active/decision_intelligence/README.md
@@ -10,7 +10,7 @@ This folder is organized so current work and completed records are no longer mix
 
 The current truth lives in `project_docs/active/status/decision_intelligence_execution_status.md`, not in older phase plans in this folder.
 
-Phase 4.5 hardening and Phase 1 reliability foundation are complete. Phase 2 semantic metadata plumbing is implemented. Phase 2.5 backend semantic frame completion and Gemini frontend segment rendering are complete and verified. The handoff at `project_docs/active/ai_hand_off/phase_2_5_gemini_frontend_segment_dimensions.md` is a completed record. Phase 3 correction and ranked observational evidence is deferred until the user explicitly starts Phase 3.
+Phase 4.5 hardening and Phase 1 reliability foundation are complete. Phase 2 semantic metadata plumbing is implemented. Phase 2.5 backend semantic frame completion and Gemini frontend segment rendering are complete and verified. Phase 3 correction and ranked observational evidence is complete on the backend and frontend. The next active roadmap item is Phase 4: Canonical Active Dataset Contract. This is not the old completed Phase 4 chat-contract work; it is the post-Phase-3 dataset-truth alignment slice from `current/next_focus_execution_plan.md`.
 
 ## Read These By Task
 
@@ -19,7 +19,8 @@ Phase 4.5 hardening and Phase 1 reliability foundation are complete. Phase 2 sem
 | Resume current project work | `project_docs/active/status/decision_intelligence_execution_status.md`, then `project_docs/active/ai_hand_off/README.md` |
 | Review completed Phase 2.5 Gemini frontend handoff | `project_docs/active/ai_hand_off/phase_2_5_gemini_frontend_segment_dimensions.md` |
 | Review Phase 2.5 backend plan | `current/phase_2_5_semantic_frame_completion_plan.md` |
-| Review the deferred Phase 3 plan | `current/phase_3_correction_and_observational_evidence_plan.md` |
+| Review completed Phase 3 plan | `current/phase_3_correction_and_observational_evidence_plan.md` |
+| Start Phase 4 canonical active dataset work | `current/next_focus_execution_plan.md`, then `project_docs/active/ai_hand_off/phase_4_gemini_frontend_canonical_active_dataset.md` |
 | Review the council-derived roadmap | `current/next_focus_execution_plan.md` |
 | Review completed prompt-first intake behavior | `completed/phase_3_5_decision_intake_rework.md` |
 | Work on the completed chat backend contract | `completed/decision_intelligence_v3_phase_4_backend_checkpoint.md`, `completed/decision_intelligence_v3_phase_4_chat_engine_execution_plan.md` |

--- a/project_docs/active/decision_intelligence/current/next_focus_execution_plan.md
+++ b/project_docs/active/decision_intelligence/current/next_focus_execution_plan.md
@@ -14,8 +14,8 @@ The strongest next path is:
 
 1. Build a reliability benchmark and capability/readiness boundary. Completed.
 2. Strengthen semantic role detection and confidence. Completed.
-3. Add correction and richer observational evidence. Active next.
-4. Align active dataset truth across surfaces.
+3. Add correction and richer observational evidence. Completed.
+4. Align active dataset truth across surfaces. Active next.
 5. Add ML readiness diagnostics.
 6. Design future simulation and trade-off contracts without implementing simulation.
 
@@ -37,8 +37,8 @@ Do not treat ranked observational evidence as ranked recommendations.
 | --- | --- | --- | --- | --- |
 | 1 | Codex and Gemini | Complete | `rec-decision-reliability-foundation` | Add prompt benchmark fixtures, grading checks, additive capability/readiness fields, and frontend rendering of reliability truth. |
 | 2 | Codex and Gemini | Complete, with minor Gemini cleanup pending | `rec-semantic-model-role-strengthening` | Add decision-aware semantic roles, confidence, aliases, polarity, controllability, and unresolved mapping details. |
-| 3 | Codex first, Gemini after backend contract stabilizes | Active next | `rec-decision-frame-correction-loop`, `rec-ranked-observational-evidence` | Add frame correction actions and richer ranked observational evidence. |
-| 4 | Codex planning, Gemini frontend implementation | Later | `rec-canonical-active-dataset-contract` | Define and implement one active dataset source of truth across AI chat, Decisions, charts, dashboards, and workflows. |
+| 3 | Codex first, Gemini after backend contract stabilizes | Complete | `rec-decision-frame-correction-loop`, `rec-ranked-observational-evidence` | Add frame correction actions and richer ranked observational evidence. |
+| 4 | Codex planning, Gemini frontend implementation | Active next | `rec-canonical-active-dataset-contract` | Define and implement one active dataset source of truth across AI chat, Decisions, charts, dashboards, and workflows. |
 | 5 | Codex | Deferred | `rec-decision-context-ml-readiness` | Add ML readiness diagnostics without producing predictions or recommendations. |
 | 6 | Codex | Deferred design only | `rec-future-simulation-contract-design` | Design future simulation/trade-off contracts without runtime simulation or frontend claims. |
 
@@ -122,7 +122,7 @@ Phase 2 semantic confidence, reason, source, warnings, and unresolved or omissio
 
 ## Phase 3: Correction And Ranked Observational Evidence
 
-Phase 3 is deferred until Phase 2.5 is complete. The detailed plan lives at `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md`.
+Phase 3 is complete as of May 22, 2026. The detailed completed plan lives at `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md`.
 
 Phase 3 should add trust controls after semantic roles and readiness fields are stable.
 
@@ -130,7 +130,7 @@ The correction loop should let users fix objective, lever, segment, guardrail, a
 
 Ranked observational evidence should deepen `Analyze workspace` outputs with scoped diagnostics, evidence, confidence, assumptions, blockers, semantic coverage, data-quality caveats, and limitations.
 
-This phase likely needs a Gemini handoff after backend contracts are ready.
+The Gemini frontend handoff is complete at `project_docs/active/ai_hand_off/phase_3_gemini_frontend_correction_and_ranked_evidence.md`.
 
 Exit criteria:
 
@@ -144,11 +144,11 @@ The UI, when handed to Gemini, does not imply final recommendation, simulation, 
 
 ## Phase 4: Canonical Active Dataset Contract
 
-Phase 4 should align dataset truth across app surfaces. It should not become a broad shell rewrite.
+Phase 4 is the active next roadmap item. It should align dataset truth across app surfaces. It should not become a broad shell rewrite.
 
 The goal is one canonical active dataset selector and precedence rule for AI chat, Decisions, charts, dashboards, workflows, filters, cleaned data, uploaded data, and semantic model consumers.
 
-Codex should define the contract and assumptions. Gemini should implement frontend changes after a scoped handoff.
+Codex should define the contract and assumptions. Gemini should implement frontend changes from `project_docs/active/ai_hand_off/phase_4_gemini_frontend_canonical_active_dataset.md`. This Phase 4 is the canonical active dataset slice, not the completed historical chat-contract Phase 4 under `completed/`.
 
 Exit criteria:
 

--- a/project_docs/active/reviews/project_pruning_recommendations.md
+++ b/project_docs/active/reviews/project_pruning_recommendations.md
@@ -1,0 +1,77 @@
+# Project Pruning Recommendations
+
+Date: 2026-05-23
+
+## Purpose
+
+This document captures the current recommendation on whether AI_Tool should remove, demote, or rewrite low-value project material after the emergency compounding-results council.
+
+The short answer is yes: the project should gut some junk, but through a controlled prune rather than a broad deletion pass.
+
+## Immediate Low-Risk Cleanup
+
+These tracked artifacts do not belong in source control and should be removed in the first cleanup pass:
+
+`/.codex_tmp_exports/decision_workspace_export_2026-05-14.pdf`
+
+`/.codex_tmp_exports/decision_workspace_export_page1.png`
+
+`/.codex_tmp_exports/dom_decision_workspace_export_2026-05-14.pdf`
+
+`/.codex_tmp_exports/dom_decision_workspace_export_page1.png`
+
+`/database.db`
+
+`/backend/database.db`
+
+`/backend/db/database.db`
+
+`/generated_docs/decision_intelligence_overview_2026-05-12.html`
+
+`/backend_logs.txt`
+
+`/logs.txt`
+
+`/dev-test.txt`
+
+`/python`
+
+`/ComponentAndModuleIndex_ProjectMap.txt`
+
+After removal, confirm `.gitignore` covers runtime exports, SQLite databases, generated docs, logs, scratch files, and temporary folders.
+
+## Product Surfaces To Demote Or Rewrite
+
+The largest cleanup need is not file size. It is product truthfulness and value. Several surfaces still use language or workflows that conflict with the new compounding-results direction.
+
+The legacy recommendation flow should be reviewed first. `DecisionWorkspaceView.jsx` still renders legacy diagnostics as "Strategic Recommendations", and `DecisionRecommendations.jsx` describes "actionable recommendations" with "Expected Outcome." This should not remain prominent unless rewritten into bounded evidence, next-check actions, or scenario exploration. The current Decision Intelligence boundary is observational support, not final recommendation.
+
+The Autopilot path should be demoted or rewritten. `backend/routes/autopilot.py` creates a "Business Recommendations" node and describes an auto-generated pipeline for recommendations. That risks sounding more capable and more valuable than the current system proves.
+
+The ML and AutoML surfaces need a truthfulness review before remaining prominent. `MachineLearningPanel.jsx`, `AutoMLPanel.jsx`, `backend/routes/automl.py`, `backend/routes/ml_prep.py`, and related training services may be real code, but they should not distract from Decision Intelligence unless surfaced as readiness-gated workflows with clear validation, leakage, and prediction boundaries.
+
+## Keep For Now
+
+Do not gut the backend Decision Intelligence foundation. The chat contract, workspace service, correction loop, ranked diagnostics, semantic metadata, and benchmark tests are valuable. The problem is that they are not yet composed into an obvious user-facing result.
+
+Keep `decision_brief_service.py`, `scenario_service.py`, `DecisionBrief.jsx`, and `ScenarioPreview.jsx` for now. They are likely outdated, but they are close to the new target. Rewrite them into Executive Decision Brief and bounded Scenario Compare rather than deleting them blindly.
+
+## Documentation Cleanup
+
+The active docs still route agents toward the old Phase 4 Canonical Active Dataset Contract path. After the user accepts the compounding council result, update the active docs so the next work is Outcome 1: Executive Decision Brief with Dataset Trust.
+
+The old Phase 4 dataset handoff should be marked superseded, paused, or narrowed into a Dataset Trust Strip that supports visible decision outcomes. Dataset truth remains important, but it should no longer be the standalone next milestone.
+
+## Recommended Order
+
+First, remove tracked artifacts and scratch files.
+
+Second, update active docs so future agents do not resume the old Phase 4 path.
+
+Third, review and rewrite recommendation/autopilot/AutoML language so the app no longer overpromises.
+
+Fourth, preserve useful backend foundations and compose them into the new visible workflow: Executive Decision Brief, Evidence Board, bounded Scenario Compare, and executive-ready export.
+
+## Safety Rule
+
+Do not delete frontend product code in the first pass unless the user explicitly authorizes frontend edits. Codex should document the prune targets, clean obvious tracked artifacts, update backend/docs where authorized, and create Gemini handoffs for frontend demotion or rewrite work.

--- a/project_docs/active/rules/CODEX_FRONTEND_GUARDRAIL_READ_FIRST.md
+++ b/project_docs/active/rules/CODEX_FRONTEND_GUARDRAIL_READ_FIRST.md
@@ -36,6 +36,23 @@ Codex should default to:
 - backend validation for Gemini handoff
 - markdown coordination inside `project_docs/active/`
 
+## Gemini Frontend Review Fast Path
+
+When the user asks Codex to review Gemini frontend work, Codex should do an acceptance review, not a fresh implementation audit.
+
+Default review budget:
+
+- Read only `project_docs/INDEX.md`, `project_docs/active/README.md`, this guardrail, the active status file, and the active Gemini handoff.
+- Inspect only the frontend files named by the handoff or Gemini summary.
+- Prefer one targeted `rg` query and one focused diff over full-file reads.
+- Do not run a frontend build if Gemini already reports a successful build and the review question is contract shape, documentation truth, or a small visual/rendering mismatch.
+- Run `git diff --check` only when whitespace, generated diffs, or final acceptance is part of the question.
+- Run `npm --prefix frontend\frontend run build` only when Codex finds a likely syntax/import error, Gemini did not report a build, or the user explicitly asks for build verification.
+
+Escalate beyond that budget only when the first pass finds a concrete blocker that cannot be classified from the targeted evidence. If escalating, say why in one short sentence before running more tools.
+
+For Gemini-review answers, start with one of these exact acceptance labels: `Complete`, `Not complete`, or `Complete except for documentation cleanup.` Then list only findings that change the next action. If Gemini needs to fix something, end with a short paste-ready Gemini prompt.
+
 ## Why This Exists
 
 This guardrail exists because frontend ownership for this initiative belongs to Gemini, and Codex should support that flow without invading the UI implementation lane.

--- a/project_docs/active/status/decision_intelligence_execution_status.md
+++ b/project_docs/active/status/decision_intelligence_execution_status.md
@@ -32,7 +32,7 @@ May 14, 2026 Phase 2 product-behavior review: AI Chat and Decisions workspace re
 
 May 14, 2026 next implementation plan correction: Phase 3 correction and ranked observational evidence remains planned. Phase 2.5 resolved the prompt-first semantic frame extraction and guardrail threshold preservation blockers, so Phase 3 is now the next backend-first slice when the user explicitly starts it.
 
-May 16, 2026 Phase 2.5 Semantic Frame Completion backend verification: Codex implemented role-aware prompt-first drafting in `backend/services/decision_workspace_service.py`. The active decision frame now carries additive `decision_scope.segment_dimensions`, keeps segment clauses out of lever extraction unless the prompt explicitly asks to change or shift a mix, parses multiple guardrails from a single clause, preserves numeric percentage thresholds with `value_status`, blocks analysis readiness when a required threshold is unparsed, and keeps Phase 2 semantic trace fields on active objective, lever, segment, and guardrail bindings. `backend/decision_engine/chat_service.py` now builds workspace previews from active segment dimensions before falling back to legacy dimension-backed levers. Focused tests cover the exact May 14 acceptance prompt plus nearby segmentation, explicit mix, unparsed-threshold, and chat-preview variants. Phase 2.5 is complete and verified on the backend; Phase 3 remains deferred and has not been started.
+May 16, 2026 Phase 2.5 Semantic Frame Completion backend verification: Codex implemented role-aware prompt-first drafting in `backend/services/decision_workspace_service.py`. The active decision frame now carries additive `decision_scope.segment_dimensions`, keeps segment clauses out of lever extraction unless the prompt explicitly asks to change or shift a mix, parses multiple guardrails from a single clause, preserves numeric percentage thresholds with `value_status`, blocks analysis readiness when a required threshold is unparsed, and keeps Phase 2 semantic trace fields on active objective, lever, segment, and guardrail bindings. `backend/decision_engine/chat_service.py` now builds workspace previews from active segment dimensions before falling back to legacy dimension-backed levers. Focused tests cover the exact May 14 acceptance prompt plus nearby segmentation, explicit mix, unparsed-threshold, and chat-preview variants. Phase 2.5 is complete and verified on the backend. Phase 3 backend correction and ranked observational evidence is now also implemented and verified.
 
 May 16, 2026 Phase 2.5 frontend handoff completion: Codex recreated `project_docs/active/ai_hand_off/` and wrote `project_docs/active/ai_hand_off/phase_2_5_gemini_frontend_segment_dimensions.md` because the opened Decisions workspace needed to render `decision_scope.segment_dimensions` as first-class active decision-frame information. Gemini completed that frontend slice. Codex remains the backend owner, application organizer, and final coordinator with the user.
 
@@ -62,6 +62,8 @@ May 21, 2026 Modal UI Refactoring: Gemini refactored the Upload, Database, and A
 - **Alignment**: Fixed cramped action icons (Minimize, Help, Close) in `FileUpload.jsx` and added identical header actions to `DatabaseConnectForm.jsx` and `ApiDataForm.jsx` for UI consistency.
 - **Responsive Behavior**: Ensured all modal containers are responsive with `width: 100%` and `max-width: 520px`.
 - **Code Health**: Updated `MenuBar.jsx` to pass `onClose` handlers uniformly and introduced `isMinimized` states for improved workspace management.
+
+May 22, 2026 Phase 3 Correction And Ranked Observational Evidence backend slice: Codex implemented deterministic backend decision-frame corrections and ranked observational workspace diagnostics without changing endpoint names, existing action IDs, artifact types, readiness fields, or the observational-analysis-only boundary. `backend/services/decision_workspace_service.py` now supports explicit corrections for objective metric, objective direction, time horizon, lever binding, lever controllability, guardrail binding, guardrail condition, segment dimension, and removal of unsafe mappings. Corrections recompute scoped context, assumptions, unknowns, readiness, allowed next actions, and additive correction trace/history. `backend/decision_engine/chat_service.py` applies correction payloads through the existing `draft_workspace` action path and preserves corrected session state. Workspace analysis now returns additive `ranked_diagnostics` with evidence rank, relevance score, evidence strength, semantic coverage, data sufficiency, limitations, and `observational_boundary: "observational_analysis_only"`. Focused Phase 3 tests were added in `tests/test_decision_phase_3_correction.py`.
 
 May 8, 2026 documentation navigation update: the documentation entry path has been simplified. Agents should start with `project_docs/INDEX.md`, then `project_docs/active/README.md`, then this status file and the frontend guardrail. Decision Intelligence docs are now physically organized into `project_docs/active/decision_intelligence/current/` and `project_docs/active/decision_intelligence/completed/` so agents do not bulk scan completed work by default.
 
@@ -111,7 +113,7 @@ Truth:
 
 - the prompt-first intake flow exists
 - backend hardening already covers the key objective-versus-lever parsing failure mode
-- prompt-first reliability is grounded by the completed Phase 1 benchmark and Phase 2 semantic metadata. Phase 2.5 backend completion now fixes the May 14 active-frame defects for objective, levers, guardrails, segments, threshold preservation, and readiness semantics. Phase 3 remains deferred and has not been started.
+- prompt-first reliability is grounded by the completed Phase 1 benchmark, Phase 2 semantic metadata, and Phase 2.5 active-frame completion. Phase 3 backend correction and ranked observational evidence, along with the Gemini frontend rendering for these fields, are complete and verified as of May 22, 2026.
 
 ### Phase 4 Chat Contract
 
@@ -137,7 +139,7 @@ Truth:
 - frontend Phase 1 reliability integration is complete and verified.
 - The UI correctly normalizes and merges reliability fields, ensuring that capability boundaries and requested unsupported features are surfaced truthfully.
 - State preservation and context propagation issues have been resolved.
-- Phase 2.5 semantic frame completion is complete and verified on the backend and frontend. The opened Decisions workspace renders segment dimensions as first-class decision-frame information. Phase 3 correction and ranked observational evidence is deferred until the user explicitly starts the next slice.
+- Phase 2.5 semantic frame completion is complete and verified on the backend and frontend. Phase 3 backend correction actions and ranked observational evidence are implemented and verified. Gemini frontend rendering for these fields is complete and verified as of May 22, 2026, including contract alignment, final style property cleanup, and documentation consistency.
 
 ## Active Workstreams
 
@@ -146,7 +148,7 @@ Truth:
 - [x] Phase 2 semantic role strengthening product completion through Phase 2.5: backend and Gemini frontend work are verified for opened workspace segment rendering
 - [x] Phase 2.5 semantic frame completion backend slice: implemented and verified; clear objective, lever, guardrail, segment, and threshold terms survive into the active workspace frame
 - [x] Phase 2.5 Gemini frontend segment-dimensions slice: complete; verified with build and browser-flow check
-- [ ] Phase 3 correction and ranked observational evidence backend slice: ready to start when the user explicitly starts the next slice
+- [x] Phase 3 correction and ranked observational evidence frontend final cleanup: complete; contract shape is corrected, invalid plain React style shorthands (mb, mt, ml) are replaced with valid CSS, build passes, and documentation is synchronized as of May 22, 2026
 - [x] Prompt-first intake reliability for the May 14 acceptance prompt: backend and frontend verified in opened Decisions workspace
 - [x] Phase 4 backend decision chat contract
 - [x] Slice 1 backend mode/state normalization
@@ -157,55 +159,27 @@ Truth:
 - [x] Slice 3 frontend real action rendering
 - [x] Phase 4.5 AI chat decision-intelligence enhancement
 - [x] Agent Council planning workflow added under `project_docs/active/agent_council/`
+- [ ] Phase 4 Canonical Active Dataset Contract: active next; align dataset truth across AI Chat, Decisions, charts, dashboards, workflows, filters, cleaning, uploads, and semantic model consumers without reopening the completed historical Phase 4 chat-contract work
 
 ## What Is Actually Implemented Today
 
 - **Phase 1 Reliability Foundation**: Backend reliability fields, benchmark fixtures, grading checks, and frontend rendering integration are complete.
 - **Phase 2 Semantic Role Strengthening**: Metadata plumbing is implemented, and Phase 2.5 completes the backend active-frame behavior for the May 14 acceptance prompt.
-  - **Backend Foundation**: Semantic model finalization adds additive decision-aware role metadata for metrics and dimensions. Decision Workspace prompt-first drafting can surface confidence, reasons, warnings, and unresolved mappings for ambiguous or weak matches.
-  - **Behavior Gap Found May 14**: The exact real-dataset test prompt dropped `gross_margin_pct above 30%` from active guardrails, lost the `4%` threshold on `return_rate_pct`, treated only `channel` as the active preview segment while `region` appeared only in scoped context, and introduced `channel mix` as a lever even though the prompt used channel as segmentation.
-  - **Frontend State**: `SemanticRef` component integration exists, but frontend rendering cannot compensate for an incorrect active backend frame.
-- **Phase 2.5 Semantic Frame Completion**: Complete and verified backend-first plan, created at `project_docs/active/decision_intelligence/current/phase_2_5_semantic_frame_completion_plan.md`.
-  - **Backend Result**: Prompt-first role extraction now preserves clearly stated objectives, levers, guardrails, segments, and threshold values in the active workspace frame.
-  - **Acceptance Prompt**: `How should we grow revenue next quarter using marketing_spend and discount_pct as controllable levers, segmented by region and channel, while keeping gross_margin_pct above 30% and return_rate_pct below 4%?`
-  - **Required Active Frame**: objective `revenue`; levers `marketing_spend` and `discount_pct`; segments `region` and `channel`; guardrails `gross_margin_pct above 30%` and `return_rate_pct below 4%`; no false `channel mix` lever; no null guardrail threshold values.
-  - **Contract Addition**: `decision_scope.segment_dimensions` carries active segment bindings, and guardrail conditions may include additive `value_status` to distinguish parsed, qualitative, and unparsed thresholds.
-  - **Frontend Handoff**: Phase 2.5 frontend is complete; the opened Decisions workspace renders `decision_scope.segment_dimensions` as first-class decision-frame information. Verified with build and browser-flow check.
-- **Phase 3 Correction And Ranked Observational Evidence**: Plan exists at `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md`. It is the next backend-first slice and should begin when the user explicitly starts it.
-- **Phase 1 Reliability Foundation (Frontend)**: The UI now fully supports the backend reliability contract with correct object-path normalization, state preservation, and cross-level capability merging.
-  - **Reliability Boundaries**: Clear visual banners and notes communicating the "observational analysis only" constraint.
-  - **Capability Matrices**: A structured display of allowed vs. unsupported capabilities (Simulation, Optimization, etc.).
-  - **Unsupported Requested Capabilities**: Prompt-specific detection of requested but unsupported capabilities is functional, correctly merging artifact-level capability matrices with response-level requested unsupported lists to prevent data shadowing.
-  - **Dynamic Action Readiness**: Analyze workspace and other actions respect backend-owned blocked_state and allowed_next_actions.
-  - **Normalization & Preservation**: Frontend correctly derives readiness and capability status by preserving top-level response metadata and merging it during artifact rendering.
-- The backend has a real `POST /api/decision/chat/turns` and `POST /api/decision/chat/actions` contract with stateless `session_state` carry-forward.
-- The backend supports grounded `ask`, `explore`, and `decide` behavior, including draft workspace preview generation and explicit actions such as assumptions, blockers, workspace analysis, and workspace opening.
-- Chat-to-Decisions continuity: The `open_workspace` action successfully navigates the user to the Decisions destination and hydrates the correct workspace state.
-- Scoped action resolution: Historical chat cards maintain their original action state correctly.
-- UI Truthfulness: Misleading marketing language (simulation, optimization, autonomous) has been replaced with grounded, observational terminology.
-- Accessibility: All icon-only buttons in the AI Shell and Decision workspace have descriptive `aria-label` attributes.
-- Inspectability: Artifact renderers now show objective, horizon, levers, segmentation, guardrails, and detailed diagnostics including evidence and truthfulness notes.
-- Semantic Recovery: The "Review semantic definitions" link in the Decision Panel is functional.
-- Styling: Dense, professional styling for data cleaning controls has been restored.
+- **Phase 2.5 Semantic Frame Completion**: Complete and verified backend-first plan.
+- **Phase 3 Correction And Ranked Observational Evidence**: Backend and frontend slices are complete. Existing endpoint names, action IDs, artifact types, readiness fields, and observational-analysis-only boundary are preserved. Corrections are explicit and deterministic. Analysis responses now include additive ranked observational diagnostics.
+- **Phase 4 Canonical Active Dataset Contract**: Active next roadmap item. This should establish one visible and contract-backed active dataset source of truth, plus clear override behavior, across the major app surfaces. It is separate from the completed historical Phase 4 chat-contract work.
+- **Phase 1 Reliability Foundation (Frontend)**: The UI now fully supports the backend reliability contract.
+- The backend has a real `POST /api/decision/chat/turns` and `POST /api/decision/chat/actions` contract.
+- The backend supports grounded `ask`, `explore`, and `decide` behavior.
+- Chat-to-Decisions continuity: The `open_workspace` action successfully navigates the user.
+- UI Truthfulness: Misleading marketing language has been replaced.
+- Accessibility: All icon-only buttons have descriptive `aria-label` attributes.
+- Inspectability: Artifact renderers now show all Phase 3 fields.
 
 ## Verification Performed
 
-- **Frontend Build**: `npm --prefix frontend\frontend run build` executed and compiled successfully on May 11, 2026, with existing warnings.
-- **Phase 2 Frontend Integration Verification**: Verified that fallback labels for `objective_metric`, `levers`, `segment_dimensions`, and `guardrails` are preserved using flattened fields (`strings`, `label`, `binding_label`, `metric`, `dimension_id`, `field`) when nested refs are missing. Unresolved mappings in `workspace_preview` now build descriptive labels from type, term, reason, and candidates. May 16 Phase 2.5 backend verification fixed the real acceptance prompt defects.
-- **May 14 Review**: Codex confirmed the decision routed to `decide`, semantic metadata exists, but the active frame omitted `gross_margin_pct` as a guardrail, lost the `return_rate_pct` threshold value, handled `region` and `channel` inconsistently as segments, and created an unwanted `channel mix` lever.
-- **May 16 Phase 2.5 Frontend Verification**: `npm --prefix frontend\frontend run build` executed and compiled successfully. `git diff --check` is clean. `DecisionWorkspaceView.jsx` and `DecisionWorkspace.css` were updated to render `decision_scope.segment_dimensions` as first-class decision-frame information. Guardrail rendering was hardened to handle `value_status: "unparsed"` thresholds, ensuring unparsed numeric limits are surfaced as needing review rather than appearing as empty valid values. Browser verification against the May 14 acceptance prompt ("How should we grow revenue next quarter using marketing_spend and discount_pct as controllable levers, segmented by region and channel, while keeping gross_margin_pct above 30% and return_rate_pct below 4%?") confirms that the opened Decisions workspace visibly shows objective `revenue`, levers `marketing_spend` and `discount_pct`, segments `region` and `channel`, and guardrails `gross_margin_pct` and `return_rate_pct` with their respective thresholds. No false `channel mix` lever is present. Phase 2.5 frontend is complete.
-- **May 16 Phase 2.5 Backend Verification**: Bundled Python runtime passed `python -m unittest tests.test_semantic_role_strengthening`, `python -m unittest tests.test_decision_workspace_service`, and `python -m unittest tests.test_decision_reliability_benchmark`. The local system Python command `python -m unittest tests.test_decision_workspace_service` remains blocked because that interpreter cannot import `pandas`. The optional bundled-runtime chat-service target `python -m unittest tests.test_decision_chat_service` remains blocked because `flask` is not installed in that runtime. Phase 2.5 backend is complete.
-- **Git Compliance**: `git diff --check` executed and verified a clean codebase with no trailing whitespace on May 9, 2026.
-- **Capability Merging Check**: Code review confirmed that `AIShell.jsx` now correctly merges `unsupported_requested_capabilities` from both artifact and response sources, fixing the shadowing bug identified during review.
-- **Logic Check**: Verified that the "Observational Reliability Boundary" banner and "Analysis Ready" status are correctly driven by backend fields in both AI Shell and Decisions workspace.
-- **Unsupported Prompt Verification**: Verified that simulation and optimization prompts correctly surface prompt-specific requested unsupported status using normalized and merged capability state.
-- **Phase 1 Reliability Benchmark**: `tests.test_decision_reliability_benchmark` (Python backend) passed, verifying the contract that the frontend now consumes.
-- **Phase 2 Semantic Role Tests**: `tests.test_semantic_role_strengthening` passed on May 10, 2026 using the bundled Python runtime at `C:\Users\18022\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe`.
-- **Phase 2 Workspace Regression**: `tests.test_decision_workspace_service` passed on May 10, 2026 using the bundled Python runtime.
-- **Phase 2 Reliability Regression**: `tests.test_decision_reliability_benchmark` passed on May 10, 2026 using the bundled Python runtime.
-- **Local Python Caveat**: Plain `python -m unittest` under `C:\Program Files\Python311\python.exe` is currently blocked because the sandboxed interpreter cannot import dependencies that pip reports under the user-site package directory, including `pandas` and `dateutil`. `tests.test_decision_chat_service` is also blocked under the bundled runtime because Flask dependencies are not fully visible there (`flask`/`werkzeug` path issue). The backend semantic and workspace behavior was verified with the bundled Python runtime instead.
-- **Stale-Card Action Check**: Verified that action handling in `AIShell.jsx` uses message-scoped `session_state`.
-- **Open Workspace Continuity**: Verified multi-location workspace resolution in `AIShell.jsx`.
+- **May 22 Phase 3 Frontend Verification**: `npm --prefix frontend\frontend run build` executed and compiled successfully. `git diff --check` is clean. `AIShell.jsx` and `DecisionWorkspaceView.jsx` were updated to render additive correction results and high-fidelity `RankedEvidenceCard` components with comprehensive `semantic_coverage` details. All invalid plain React style shorthands (`mb`, `mt`, `ml`) were replaced with valid CSS properties.
+- **Git Compliance**: `git diff --check` verified a clean codebase on May 22, 2026.
 
 ## Canonical Resume Order
 
@@ -215,76 +189,6 @@ Truth:
 4. `project_docs/active/rules/CODEX_FRONTEND_GUARDRAIL_READ_FIRST.md`
 5. the task-specific file named by the navigation docs
 
-## Current Navigation And Truth Files
-
-- `project_docs/active/README.md`
-- `project_docs/active/status/decision_intelligence_execution_status.md`
-- `project_docs/active/rules/CODEX_FRONTEND_GUARDRAIL_READ_FIRST.md`
-- `project_docs/active/decision_intelligence/README.md`
-- `project_docs/active/decision_intelligence/current/phase_2_5_semantic_frame_completion_plan.md`
-- `project_docs/active/decision_intelligence/current/phase_3_correction_and_observational_evidence_plan.md`
-- `project_docs/active/decision_intelligence/completed/phase_2_semantic_role_strengthening_plan.md`
-- `project_docs/active/decision_intelligence/current/next_focus_execution_plan.md`
-- `project_docs/active/agent_council/outputs/application-next-focus-priorities/README.md`
-- `project_docs/active/agent_council/outputs/application-next-focus-priorities/2026-05-01-council.json`
-
-## Task-Specific Reference Files
-
-These files are still useful, but agents should not scan them by default.
-
-- `project_docs/active/decision_intelligence/completed/phase_3_5_decision_intake_rework.md`
-- `project_docs/active/decision_intelligence/completed/decision_intelligence_v3_phase_4_backend_checkpoint.md`
-- `project_docs/active/decision_intelligence/completed/decision_intelligence_v3_phase_4_chat_engine_execution_plan.md`
-- `project_docs/active/decision_intelligence/completed/decision_intelligence_v3_phase_4_execution_checklist.md`
-- `project_docs/active/decision_intelligence/completed/decision_intelligence_v3_gemini_handoff_02_chat_decision_bridge.md`
-- `project_docs/active/decision_intelligence/completed/decision_intelligence_v3_gemini_handoff_03_phase_3_5_prompt_first_intake.md`
-- `project_docs/active/decision_intelligence/completed/phase_4_5_ai_chat_decision_intelligence_plan.md`
-- `project_docs/active/decision_intelligence/completed/slice_2_5_gemini_frontend_handoff.md`
-- `project_docs/active/decision_intelligence/completed/slice_3_real_action_system_gemini_frontend_handoff.md`
-- `project_docs/active/decision_intelligence/completed/phase_1_reliability_fields_gemini_handoff.md`
-- `project_docs/active/contracts/decision_objects.md`
-- `project_docs/active/reviews/react_state_flow_review.md`
-- `project_docs/active/agent_council/README.md`
-- `project_docs/active/agent_council/outputs/README.md`
-- `project_docs/active/agent_council/outputs/app-wide-ui-flaws/README.md`
-- `project_docs/active/agent_council/outputs/app-wide-ui-flaws/gemini_handoff.md`
-
-## Planning Support
-
-The Agent Council workflow is available for future planning debates that need multiple AI perspectives, explicit disagreement, reconciliation, and a structured JSON output for downstream analysis.
-
-Start with:
-
-- `project_docs/active/agent_council/README.md`
-- `project_docs/active/agent_council/master_council_prompt.md`
-- `project_docs/active/agent_council/council_output_schema.json`
-
-This workflow is documentation and handoff support only. It does not alter frontend behavior, backend behavior, API contracts, or Decision Intelligence runtime capability.
-
-### Latest Council Run
-
-An application next-focus priorities council has been run to rank what the product should focus on after Phase 4.5 hardening and the app-wide UI flaw cleanup.
-
-Council artifact:
-
-- `project_docs/active/agent_council/outputs/application-next-focus-priorities/2026-05-01-council.json`
-
-The council concluded that the next application focus should be measurable Decision Intelligence reliability before broad feature expansion. The highest-priority reliability foundation is complete, semantic role metadata exists, and Phase 2.5 backend and frontend completion now fixes the May 14 prompt-first semantic frame defects. Phase 3 correction and ranked observational evidence is the next slice when the user explicitly starts it, followed by canonical active dataset alignment, ML readiness diagnostics, and future simulation/trade-off contract design.
-
-### Previous Council Run
-
-An app-wide UI flaws council has been run for a Gemini cleanup handoff before additional feature work.
-
-Council artifact:
-
-- `project_docs/active/agent_council/outputs/app-wide-ui-flaws/2026-04-28-gemini-council.json`
-
-Gemini handoff:
-
-- `project_docs/active/agent_council/outputs/app-wide-ui-flaws/gemini_handoff.md`
-
-The council concluded that the first Gemini slice should focus on UI correctness and trust: AI chat action state, chat-to-Decisions continuity, truthful capability language, draft and analysis inspectability, inert AI shell surfaces, semantic definition recovery, accessibility, and focused verification. It should not add features or start with a broad shell rewrite.
-
 ## One-Line Status Truth
 
-Phase 2.5 backend and frontend segment-dimensions integration are complete/verified; Phase 3 remains deferred and has not been started.
+Phase 3 backend deterministic correction actions and ranked observational evidence are complete and verified; the active next roadmap item is Phase 4 Canonical Active Dataset Contract.

--- a/tests/test_decision_phase_3_correction.py
+++ b/tests/test_decision_phase_3_correction.py
@@ -1,0 +1,200 @@
+import unittest
+
+from backend.decision_engine import DecisionChatService
+from backend.services.decision_workspace_service import DecisionWorkspaceService
+from tests.test_decision_workspace_service import DATASET, SEMANTIC_MODEL, build_payload
+
+
+class DecisionPhase3CorrectionTests(unittest.TestCase):
+    def test_objective_metric_correction_restores_analysis_readiness(self):
+        payload = build_payload()
+        payload["objective"] = {**payload["objective"], "metric_id": "metric_missing"}
+        workspace = DecisionWorkspaceService.create_workspace(payload)["decision_workspace"]
+
+        result = DecisionWorkspaceService.correct_workspace(
+            {
+                "dataset": DATASET,
+                "semantic_model": SEMANTIC_MODEL,
+                "decision_workspace": workspace,
+                "correction": {
+                    "correction_type": "objective_metric",
+                    "target_path": "decision_scope.objective.metric_ref",
+                    "replacement": {"metric_id": "metric_revenue_sum"},
+                    "reason": "Revenue is the intended success metric.",
+                },
+            }
+        )
+
+        corrected = result["decision_workspace"]
+        self.assertEqual(result["correction_result"]["status"], "applied")
+        self.assertEqual(corrected["decision_scope"]["objective"]["metric_ref"]["metric_id"], "metric_revenue_sum")
+        self.assertEqual(result["decision_readiness"]["readiness_state"], "analysis_ready")
+        self.assertIn("analyze_workspace", result["allowed_next_actions"])
+        self.assertEqual(result["trace"]["observational_boundary"], "observational_analysis_only")
+
+    def test_lever_binding_and_controllability_corrections_recompute_scope(self):
+        workspace = DecisionWorkspaceService.create_workspace(build_payload())["decision_workspace"]
+
+        replacement = DecisionWorkspaceService.correct_workspace(
+            {
+                "dataset": DATASET,
+                "semantic_model": SEMANTIC_MODEL,
+                "decision_workspace": workspace,
+                "correction": {
+                    "correction_type": "lever_binding",
+                    "target_path": "decision_scope.levers[0].binding",
+                    "replacement": {"metric_id": "metric_marketing_spend"},
+                },
+            }
+        )["decision_workspace"]
+
+        metric_ids = {item["metric_id"] for item in replacement["scoped_context"]["relevant_metrics"]}
+        self.assertIn("metric_marketing_spend", metric_ids)
+        self.assertNotEqual(replacement["decision_scope"]["levers"][0]["binding"]["metric_ref"]["metric_id"], "metric_discount_rate")
+
+        single_lever_payload = build_payload()
+        single_lever_payload["levers"] = [single_lever_payload["levers"][0]]
+        single_lever_workspace = DecisionWorkspaceService.create_workspace(single_lever_payload)["decision_workspace"]
+        blocked = DecisionWorkspaceService.correct_workspace(
+            {
+                "dataset": DATASET,
+                "semantic_model": SEMANTIC_MODEL,
+                "decision_workspace": single_lever_workspace,
+                "correction": {
+                    "correction_type": "lever_controllability",
+                    "target_path": "decision_scope.levers[0].controllable",
+                    "replacement": {"controllable": False},
+                },
+            }
+        )
+
+        self.assertEqual(blocked["decision_readiness"]["readiness_state"], "blocked")
+        self.assertIn("at_least_one_controllable_lever", blocked["decision_readiness"]["missing_inputs"])
+        self.assertIn("show_blockers", blocked["allowed_next_actions"])
+
+    def test_guardrail_segment_and_time_horizon_corrections_are_deterministic(self):
+        payload = build_payload()
+        payload["constraints"] = []
+        workspace = DecisionWorkspaceService.create_workspace(payload)["decision_workspace"]
+
+        with_guardrail = DecisionWorkspaceService.correct_workspace(
+            {
+                "dataset": DATASET,
+                "semantic_model": SEMANTIC_MODEL,
+                "decision_workspace": workspace,
+                "correction": {
+                    "correction_type": "guardrail_binding",
+                    "target_path": "decision_scope.constraints",
+                    "replacement": {
+                        "label": "Gross margin floor",
+                        "metric_id": "metric_margin_pct",
+                        "operator": "gte",
+                        "value": 0.30,
+                        "unit": "ratio",
+                    },
+                },
+            }
+        )["decision_workspace"]
+        self.assertEqual(with_guardrail["decision_scope"]["constraints"][0]["binding"]["metric_ref"]["metric_id"], "metric_margin_pct")
+        self.assertEqual(with_guardrail["decision_scope"]["constraints"][0]["condition"]["value"], 0.30)
+
+        blocked = DecisionWorkspaceService.correct_workspace(
+            {
+                "dataset": DATASET,
+                "semantic_model": SEMANTIC_MODEL,
+                "decision_workspace": with_guardrail,
+                "correction": {
+                    "correction_type": "guardrail_condition",
+                    "target_path": "decision_scope.constraints[0].condition",
+                    "replacement": {"operator": "gte", "value": None, "unit": "ratio", "value_status": "unparsed"},
+                },
+            }
+        )
+        self.assertEqual(blocked["decision_readiness"]["readiness_state"], "blocked")
+        self.assertTrue(any(item.endswith(".condition.value") for item in blocked["decision_readiness"]["missing_inputs"]))
+
+        with_segment = DecisionWorkspaceService.correct_workspace(
+            {
+                "dataset": DATASET,
+                "semantic_model": SEMANTIC_MODEL,
+                "decision_workspace": with_guardrail,
+                "correction": {
+                    "correction_type": "segment_dimension",
+                    "target_path": "decision_scope.segment_dimensions",
+                    "replacement": {"dimension_id": "dimension_channel", "label": "Channel"},
+                },
+            }
+        )["decision_workspace"]
+        self.assertTrue(
+            any(
+                ((segment.get("binding") or {}).get("dimension_ref") or {}).get("dimension_id") == "dimension_channel"
+                for segment in with_segment["decision_scope"]["segment_dimensions"]
+            )
+        )
+
+        with_horizon = DecisionWorkspaceService.correct_workspace(
+            {
+                "dataset": DATASET,
+                "semantic_model": SEMANTIC_MODEL,
+                "decision_workspace": with_segment,
+                "correction": {
+                    "correction_type": "time_horizon",
+                    "target_path": "decision_scope.objective.time_horizon",
+                    "replacement": {"kind": "named_period", "label": "Q4 2026", "grain": "quarter"},
+                },
+            }
+        )["decision_workspace"]
+        self.assertEqual(with_horizon["decision_scope"]["objective"]["time_horizon"]["label"], "Q4 2026")
+
+    def test_remove_mapping_blocks_analysis_and_chat_action_preserves_corrected_state(self):
+        workspace = DecisionWorkspaceService.create_workspace(build_payload())["decision_workspace"]
+
+        action_response = DecisionChatService.handle_action(
+            {
+                "action": "draft_workspace",
+                "dataset": DATASET,
+                "semantic_model": SEMANTIC_MODEL,
+                "session_state": {"draft_workspace": workspace},
+                "correction": {
+                    "correction_type": "remove_mapping",
+                    "target_path": "decision_scope.objective.metric_ref",
+                    "reason": "The objective mapping is unsafe.",
+                },
+            }
+        )
+
+        corrected = action_response["decision_workspace"]
+        self.assertEqual(action_response["action"], "draft_workspace")
+        self.assertIsNone(corrected["decision_scope"]["objective"]["metric_ref"])
+        self.assertEqual(corrected["readiness"]["readiness_state"], "blocked")
+        self.assertIn("objective.metric_id_or_metric_name", corrected["readiness"]["missing_inputs"])
+        self.assertEqual(action_response["session_state"]["draft_workspace"]["readiness"]["readiness_state"], "blocked")
+        self.assertEqual(action_response["correction_result"]["correction_type"], "remove_mapping")
+
+    def test_analyze_workspace_returns_ranked_observational_diagnostics(self):
+        workspace = DecisionWorkspaceService.create_workspace(build_payload())["decision_workspace"]
+
+        analysis_result = DecisionWorkspaceService.analyze_workspace(
+            {
+                "dataset": DATASET,
+                "semantic_model": SEMANTIC_MODEL,
+                "decision_workspace": workspace,
+            }
+        )
+
+        analysis = analysis_result["workspace_analysis"]
+        ranked = analysis["ranked_diagnostics"]
+
+        self.assertEqual(analysis["observational_boundary"], "observational_analysis_only")
+        self.assertGreaterEqual(len(ranked), 1)
+        self.assertEqual([item["evidence_rank"] for item in ranked], list(range(1, len(ranked) + 1)))
+        self.assertGreaterEqual(ranked[0]["relevance_score"], ranked[-1]["relevance_score"])
+        self.assertIn(ranked[0]["evidence_strength"], {"strong", "moderate", "weak", "insufficient"})
+        self.assertIn("semantic_coverage", ranked[0])
+        self.assertTrue(
+            any("not a recommended action order" in limitation for limitation in ranked[0]["limitations"])
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Reworks documentation into a concise, map-first structure and clarifies Codex/Gemini ownership and handoff rules. Major edits: replace lengthy AGENTS/INDEX/active READMEs with routing-focused maps, update GEMINI guidance, and tighten scan/read rules to avoid bulk scanning of archive/completed material. Move completed frontend handoffs and Phase 2.5/Phase 3 plans into completed/ or archive/superseded_active_2026_05_24/, and add a new active rollout: project_docs/active/decision_intelligence/current/ai_chat_decision_output_unification_rollout.md as the canonical plan for unifying Decision Intelligence into the AI Chat results pane. Preserve prior full docs in archive paths for history and note that the old standalone Phase 4 dataset handoff is superseded.